### PR TITLE
Reducing duplicate code and improving test speed

### DIFF
--- a/applications/spring-shell/src/test/java/org/springframework/sbm/BootifySimpleMuleAppIntegrationTest.java
+++ b/applications/spring-shell/src/test/java/org/springframework/sbm/BootifySimpleMuleAppIntegrationTest.java
@@ -90,7 +90,7 @@ public class BootifySimpleMuleAppIntegrationTest extends IntegrationTestBaseClas
     }
 
     private void checkRabbitMqIntegration(Channel amqpChannel)
-            throws IOException, TimeoutException, InterruptedException {
+            throws IOException, InterruptedException {
 
         String message = "{\"msgContent\": \"" + messageContent + "\"}";
         amqpChannel.basicPublish("", FIRST_QUEUE_NAME, null, message.getBytes());

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/JavaDSLActionBaseTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/JavaDSLActionBaseTest.java
@@ -39,6 +39,8 @@ import org.springframework.sbm.mule.api.toplevel.SubflowTopLevelElementFactory;
 import org.springframework.sbm.mule.api.toplevel.TopLevelElementFactory;
 import org.springframework.sbm.mule.api.toplevel.configuration.ConfigurationTypeAdapterFactory;
 import org.springframework.sbm.mule.api.toplevel.configuration.MuleConfigurationsExtractor;
+import org.springframework.sbm.mule.resource.MuleXmlProjectResourceRegistrar;
+import org.springframework.sbm.project.resource.ApplicationProperties;
 
 import java.util.List;
 
@@ -46,8 +48,9 @@ import static org.mockito.Mockito.mock;
 
 public class JavaDSLActionBaseTest {
 
-
     protected JavaDSLAction2 myAction;
+    protected MuleXmlProjectResourceRegistrar registrar;
+    protected ApplicationProperties applicationProperties;
     protected final ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
 
     @BeforeEach
@@ -80,5 +83,9 @@ public class JavaDSLActionBaseTest {
         MuleMigrationContextFactory muleMigrationContextFactory = new MuleMigrationContextFactory(new MuleConfigurationsExtractor(configurationTypeAdapterFactory));
         myAction = new JavaDSLAction2(muleMigrationContextFactory, topLevelTypeFactories);
         myAction.setEventPublisher(eventPublisher);
+
+        registrar = new MuleXmlProjectResourceRegistrar();
+        applicationProperties = new ApplicationProperties();
+        applicationProperties.setDefaultBasePackage("com.example.javadsl");
     }
 }

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLAmqpTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLAmqpTest.java
@@ -17,10 +17,7 @@ package org.springframework.sbm.mule.actions;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.SourceFile;
-import org.springframework.sbm.engine.context.ProjectContext;
-import org.springframework.sbm.mule.resource.MuleXmlProjectResourceFilter;
 import org.springframework.sbm.project.resource.RewriteSourceFileHolder;
-import org.springframework.sbm.project.resource.TestProjectContext;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -28,37 +25,6 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MuleToJavaDSLAmqpTest extends JavaDSLActionBaseTest {
-    private final static String muleXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-            "\n" +
-            "<mule xmlns:amqp=\"http://www.mulesoft.org/schema/mule/amqp\" xmlns:http=\"http://www.mulesoft.org/schema/mule/http\" xmlns=\"http://www.mulesoft.org/schema/mule/core\" xmlns:doc=\"http://www.mulesoft.org/schema/mule/documentation\"\n" +
-            "xmlns:spring=\"http://www.springframework.org/schema/beans\" \n" +
-            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
-            "xsi:schemaLocation=\"http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd\n" +
-            "http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd\n" +
-            "http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd\n" +
-            "http://www.mulesoft.org/schema/mule/amqp http://www.mulesoft.org/schema/mule/amqp/current/mule-amqp.xsd\">\n" +
-            "<amqp:connector name=\"amqpConnector\"\n" +
-            "  host=\"localhost\"\n" +
-            "  port=\"5672\"\n" +
-            "  username=\"guest\"\n" +
-            "  password=\"guest\"\n" +
-            "  doc:name=\"AMQP-0-9 Connector\"\n" +
-            "   />\n" +
-            "<flow name=\"amqp-muleFlow\">\n" +
-            "<amqp:inbound-endpoint \n" +
-            "queueName=\"sbm-integration-queue-one\"\n" +
-            "connector-ref=\"amqpConnector\"\n" +
-            "/>\n" +
-            "<!-- <http:listener config-ref=\"HTTP_Listener_Configuration\" path=\"/test\" allowedMethods=\"POST\" doc:name=\"Recieve HTTP request\"/> -->\n" +
-            "<logger message=\"payload to be sent: #[new String(payload)]\" level=\"INFO\" doc:name=\"Log the message content to be sent\"/>\n" +
-            "        <amqp:outbound-endpoint \n" +
-            "        exchangeName=\"sbm-integration-exchange\" \n" +
-            "        routingKey=\"sbm-integration-queue-two\"\n" +
-            "        responseTimeout=\"10000\"  \n" +
-            "        doc:name=\"Send to AMQP queue\"\n" +
-            "        />\n" +
-            "</flow>\n" +
-            "</mule>\n";
 
     private static final String muleInboundOutboundXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
             "\n" +
@@ -93,41 +59,9 @@ public class MuleToJavaDSLAmqpTest extends JavaDSLActionBaseTest {
             "</mule>\n";
 
     @Test
-    public void detectsMuleXMLFiles() {
-
-        ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
-                .addProjectResource("src/main/resources/mule-simple-amqp-flow.xml", muleXml)
-                .withApplicationProperties(applicationProperties)
-                .withBuildFileHavingDependencies(
-                        "org.springframework.boot:spring-boot-starter-web:2.5.5",
-                        "org.springframework.boot:spring-boot-starter-integration:2.5.5",
-                        "org.springframework.integration:spring-integration-amqp:5.4.4",
-                        "org.springframework.integration:spring-integration-stream:5.4.4",
-                        "org.springframework.integration:spring-integration-http:5.4.4"
-                )
-                .addRegistrar(registrar)
-                .build();
-
-        projectContext.search(new MuleXmlProjectResourceFilter());
-
-        assertThat(projectContext.getProjectResources().list()).hasSize(2);
-    }
-
-    @Test
     public void generatesAmqpDSLStatements() {
-        ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
-                .addProjectResource("src/main/resources/mule-simple-amqp-flow.xml", muleInboundOutboundXml)
-                .withApplicationProperties(applicationProperties)
-                .withBuildFileHavingDependencies(
-                        "org.springframework.boot:spring-boot-starter-web:2.5.5",
-                        "org.springframework.boot:spring-boot-starter-integration:2.5.5",
-                        "org.springframework.integration:spring-integration-amqp:5.4.4",
-                        "org.springframework.integration:spring-integration-stream:5.4.4",
-                        "org.springframework.integration:spring-integration-http:5.4.4"
-                )
-                .addRegistrar(registrar)
-                .build();
-        myAction.apply(projectContext);
+        addXMLFileToResource(muleInboundOutboundXml);
+        runAction();
         assertThat(projectContext.getProjectJavaSources().list()).hasSize(1);
         assertThat(projectContext.getProjectJavaSources().list().get(0).print())
                 .isEqualTo(
@@ -153,20 +87,8 @@ public class MuleToJavaDSLAmqpTest extends JavaDSLActionBaseTest {
 
     @Test
     public void generatesAMQPConnectorBean() {
-
-        ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
-                .addProjectResource("src/main/resources/mule-simple-amqp-flow.xml", muleInboundOutboundXml)
-                .withApplicationProperties(applicationProperties)
-                .withBuildFileHavingDependencies(
-                        "org.springframework.boot:spring-boot-starter-web:2.5.5",
-                        "org.springframework.boot:spring-boot-starter-integration:2.5.5",
-                        "org.springframework.integration:spring-integration-amqp:5.4.4",
-                        "org.springframework.integration:spring-integration-stream:5.4.4",
-                        "org.springframework.integration:spring-integration-http:5.4.4"
-                )
-                .addRegistrar(registrar)
-                .build();
-        myAction.apply(projectContext);
+        addXMLFileToResource(muleInboundOutboundXml);
+        runAction();
         assertThat(projectContext.getProjectJavaSources().list()).hasSize(1);
 
         List<RewriteSourceFileHolder<? extends SourceFile>> applicationProperty = projectContext

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLAmqpTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLAmqpTest.java
@@ -18,10 +18,7 @@ package org.springframework.sbm.mule.actions;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.SourceFile;
 import org.springframework.sbm.engine.context.ProjectContext;
-import org.springframework.sbm.mule.resource.MuleXml;
 import org.springframework.sbm.mule.resource.MuleXmlProjectResourceFilter;
-import org.springframework.sbm.mule.resource.MuleXmlProjectResourceRegistrar;
-import org.springframework.sbm.project.resource.ApplicationProperties;
 import org.springframework.sbm.project.resource.RewriteSourceFileHolder;
 import org.springframework.sbm.project.resource.TestProjectContext;
 
@@ -97,9 +94,6 @@ public class MuleToJavaDSLAmqpTest extends JavaDSLActionBaseTest {
 
     @Test
     public void detectsMuleXMLFiles() {
-        MuleXmlProjectResourceRegistrar registrar = new MuleXmlProjectResourceRegistrar();
-        ApplicationProperties applicationProperties = new ApplicationProperties();
-        applicationProperties.setDefaultBasePackage("com.example.javadsl");
 
         ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
                 .addProjectResource("src/main/resources/mule-simple-amqp-flow.xml", muleXml)
@@ -114,18 +108,13 @@ public class MuleToJavaDSLAmqpTest extends JavaDSLActionBaseTest {
                 .addRegistrar(registrar)
                 .build();
 
-        List<MuleXml> muleSearch = projectContext.search(new MuleXmlProjectResourceFilter());
+        projectContext.search(new MuleXmlProjectResourceFilter());
 
         assertThat(projectContext.getProjectResources().list()).hasSize(2);
     }
 
     @Test
     public void generatesAmqpDSLStatements() {
-
-        MuleXmlProjectResourceRegistrar registrar = new MuleXmlProjectResourceRegistrar();
-        ApplicationProperties applicationProperties = new ApplicationProperties();
-        applicationProperties.setDefaultBasePackage("com.example.javadsl");
-
         ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
                 .addProjectResource("src/main/resources/mule-simple-amqp-flow.xml", muleInboundOutboundXml)
                 .withApplicationProperties(applicationProperties)
@@ -164,10 +153,6 @@ public class MuleToJavaDSLAmqpTest extends JavaDSLActionBaseTest {
 
     @Test
     public void generatesAMQPConnectorBean() {
-
-        MuleXmlProjectResourceRegistrar registrar = new MuleXmlProjectResourceRegistrar();
-        ApplicationProperties applicationProperties = new ApplicationProperties();
-        applicationProperties.setDefaultBasePackage("com.example.javadsl");
 
         ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
                 .addProjectResource("src/main/resources/mule-simple-amqp-flow.xml", muleInboundOutboundXml)

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLApiKitTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLApiKitTest.java
@@ -17,7 +17,6 @@ package org.springframework.sbm.mule.actions;
 
 import org.junit.jupiter.api.Test;
 
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MuleToJavaDSLApiKitTest extends JavaDSLActionBaseTest {
@@ -34,6 +33,10 @@ public class MuleToJavaDSLApiKitTest extends JavaDSLActionBaseTest {
     @Test
     public void generatesApiKitDSLStatements() {
         addXMLFileToResource(muleXml);
+        //TODO: This requirement may be hiding a bug
+        setupProjectDependencies(
+                "org.springframework.integration:spring-integration-http:5.4.4"
+        );
         runAction();
         assertThat(projectContext.getProjectJavaSources().list()).hasSize(1);
         assertThat(projectContext.getProjectJavaSources().list().get(0).print())

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLApiKitTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLApiKitTest.java
@@ -16,13 +16,11 @@
 package org.springframework.sbm.mule.actions;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.sbm.engine.context.ProjectContext;
-import org.springframework.sbm.project.resource.TestProjectContext;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class MuleToJavaDSLApikitTest extends JavaDSLActionBaseTest {
+public class MuleToJavaDSLApiKitTest extends JavaDSLActionBaseTest {
     private final static String muleXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
             "<mule xmlns:doc=\"http://www.mulesoft.org/schema/mule/documentation\" xmlns=\"http://www.mulesoft.org/schema/mule/core\" xmlns:apikit=\"http://www.mulesoft.org/schema/mule/apikit\" xmlns:http=\"http://www.mulesoft.org/schema/mule/http\" xmlns:spring=\"http://www.springframework.org/schema/beans\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd\n" +
             "http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd\n" +
@@ -34,20 +32,9 @@ public class MuleToJavaDSLApikitTest extends JavaDSLActionBaseTest {
             "</mule>";
 
     @Test
-    public void generatesApikitDSLStatements() {
-
-        ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
-                .addProjectResource("src/main/resources/mule-apikit-flow.xml", muleXml)
-                .withApplicationProperties(applicationProperties)
-                .withBuildFileHavingDependencies(
-                        "org.springframework.boot:spring-boot-starter-web:2.5.5",
-                        "org.springframework.boot:spring-boot-starter-integration:2.5.5",
-                        "org.springframework.integration:spring-integration-stream:5.4.4",
-                        "org.springframework.integration:spring-integration-http:5.4.4"
-                )
-                .addRegistrar(registrar)
-                .build();
-        myAction.apply(projectContext);
+    public void generatesApiKitDSLStatements() {
+        addXMLFileToResource(muleXml);
+        runAction();
         assertThat(projectContext.getProjectJavaSources().list()).hasSize(1);
         assertThat(projectContext.getProjectJavaSources().list().get(0).print())
                 .isEqualTo(

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLApikitTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLApikitTest.java
@@ -17,8 +17,6 @@ package org.springframework.sbm.mule.actions;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.sbm.engine.context.ProjectContext;
-import org.springframework.sbm.mule.resource.MuleXmlProjectResourceRegistrar;
-import org.springframework.sbm.project.resource.ApplicationProperties;
 import org.springframework.sbm.project.resource.TestProjectContext;
 
 
@@ -37,10 +35,6 @@ public class MuleToJavaDSLApikitTest extends JavaDSLActionBaseTest {
 
     @Test
     public void generatesApikitDSLStatements() {
-
-        MuleXmlProjectResourceRegistrar registrar = new MuleXmlProjectResourceRegistrar();
-        ApplicationProperties applicationProperties = new ApplicationProperties();
-        applicationProperties.setDefaultBasePackage("com.example.javadsl");
 
         ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
                 .addProjectResource("src/main/resources/mule-apikit-flow.xml", muleXml)

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLDwlTransformTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLDwlTransformTest.java
@@ -16,8 +16,6 @@
 package org.springframework.sbm.mule.actions;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.sbm.engine.context.ProjectContext;
-import org.springframework.sbm.project.resource.TestProjectContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -81,20 +79,8 @@ public class MuleToJavaDSLDwlTransformTest extends JavaDSLActionBaseTest {
 
     @Test
     public void shouldTranslateDwlTransformation() {
-
-        ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
-                .addProjectResource("src/main/resources/mule-transform.xml", muleXml)
-                .withApplicationProperties(applicationProperties)
-                .withBuildFileHavingDependencies(
-                        "org.springframework.boot:spring-boot-starter-web:2.5.5",
-                        "org.springframework.boot:spring-boot-starter-integration:2.5.5",
-                        "org.springframework.integration:spring-integration-stream:5.4.4"
-                )
-                .addRegistrar(registrar)
-                .build();
-
-        myAction.apply(projectContext);
-
+        addXMLFileToResource(muleXml);
+        runAction();
         assertThat(projectContext.getProjectJavaSources().list()).hasSize(2);
         assertThat(projectContext.getProjectJavaSources().list().get(0).print())
                 .isEqualTo(
@@ -142,19 +128,8 @@ public class MuleToJavaDSLDwlTransformTest extends JavaDSLActionBaseTest {
 
     @Test
     public void shouldTransformDWLWithFile() {
-        ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
-                .addProjectResource("src/main/resources/mule-transform.xml", dwlXMLWithExternalFile)
-                .withApplicationProperties(applicationProperties)
-                .withBuildFileHavingDependencies(
-                        "org.springframework.boot:spring-boot-starter-web:2.5.5",
-                        "org.springframework.boot:spring-boot-starter-integration:2.5.5",
-                        "org.springframework.integration:spring-integration-stream:5.4.4"
-                )
-                .addRegistrar(registrar)
-                .build();
-
-        myAction.apply(projectContext);
-
+        addXMLFileToResource(dwlXMLWithExternalFile);
+        runAction();
         assertThat(projectContext.getProjectJavaSources().list()).hasSize(2);
         assertThat(projectContext.getProjectJavaSources().list().get(0).print())
                 .isEqualTo(

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLDwlTransformTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLDwlTransformTest.java
@@ -17,8 +17,6 @@ package org.springframework.sbm.mule.actions;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.sbm.engine.context.ProjectContext;
-import org.springframework.sbm.mule.resource.MuleXmlProjectResourceRegistrar;
-import org.springframework.sbm.project.resource.ApplicationProperties;
 import org.springframework.sbm.project.resource.TestProjectContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -83,9 +81,6 @@ public class MuleToJavaDSLDwlTransformTest extends JavaDSLActionBaseTest {
 
     @Test
     public void shouldTranslateDwlTransformation() {
-        MuleXmlProjectResourceRegistrar registrar = new MuleXmlProjectResourceRegistrar();
-        ApplicationProperties applicationProperties = new ApplicationProperties();
-        applicationProperties.setDefaultBasePackage("com.example.javadsl");
 
         ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
                 .addProjectResource("src/main/resources/mule-transform.xml", muleXml)
@@ -147,11 +142,6 @@ public class MuleToJavaDSLDwlTransformTest extends JavaDSLActionBaseTest {
 
     @Test
     public void shouldTransformDWLWithFile() {
-
-        MuleXmlProjectResourceRegistrar registrar = new MuleXmlProjectResourceRegistrar();
-        ApplicationProperties applicationProperties = new ApplicationProperties();
-        applicationProperties.setDefaultBasePackage("com.example.javadsl");
-
         ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
                 .addProjectResource("src/main/resources/mule-transform.xml", dwlXMLWithExternalFile)
                 .withApplicationProperties(applicationProperties)

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLHttpTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLHttpTest.java
@@ -18,8 +18,6 @@ package org.springframework.sbm.mule.actions;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.SourceFile;
 import org.springframework.sbm.engine.context.ProjectContext;
-import org.springframework.sbm.mule.resource.MuleXmlProjectResourceRegistrar;
-import org.springframework.sbm.project.resource.ApplicationProperties;
 import org.springframework.sbm.project.resource.RewriteSourceFileHolder;
 import org.springframework.sbm.project.resource.TestProjectContext;
 
@@ -44,9 +42,6 @@ public class MuleToJavaDSLHttpTest extends JavaDSLActionBaseTest {
 
     @Test
     public void shouldGenerateJavaDSLForFlowHttpMuleTag() {
-        MuleXmlProjectResourceRegistrar registrar = new MuleXmlProjectResourceRegistrar();
-        ApplicationProperties applicationProperties = new ApplicationProperties();
-        applicationProperties.setDefaultBasePackage("com.example.javadsl");
 
         ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
                 .addProjectResource("src/main/resources/mule-simple-http-flow.xml", muleXmlHttp)

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLHttpTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLHttpTest.java
@@ -17,9 +17,7 @@ package org.springframework.sbm.mule.actions;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.SourceFile;
-import org.springframework.sbm.engine.context.ProjectContext;
 import org.springframework.sbm.project.resource.RewriteSourceFileHolder;
-import org.springframework.sbm.project.resource.TestProjectContext;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -42,20 +40,8 @@ public class MuleToJavaDSLHttpTest extends JavaDSLActionBaseTest {
 
     @Test
     public void shouldGenerateJavaDSLForFlowHttpMuleTag() {
-
-        ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
-                .addProjectResource("src/main/resources/mule-simple-http-flow.xml", muleXmlHttp)
-                .withApplicationProperties(applicationProperties)
-                .withBuildFileHavingDependencies(
-                        "org.springframework:spring-context:5.3.1",
-                        "org.springframework:spring-beans:5.3.1",
-                        "org.springframework.integration:spring-integration-core:5.5.8",
-                        "org.springframework.integration:spring-integration-http:5.5.8",
-                        "org.springframework.boot:spring-boot-starter-integration:2.6.3"
-                )
-                .addRegistrar(registrar)
-                .build();
-        myAction.apply(projectContext);
+        addXMLFileToResource(muleXmlHttp);
+        runAction();
         assertThat(projectContext.getProjectJavaSources().list().size()).isEqualTo(1);
         assertThat(projectContext.getProjectJavaSources().list().get(0).print())
                 .isEqualTo("package com.example.javadsl;\n" +

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLMultipleTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLMultipleTest.java
@@ -96,9 +96,6 @@ public class MuleToJavaDSLMultipleTest extends JavaDSLActionBaseTest {
 
     @Test
     public void detectsMuleXMLFiles() {
-        MuleXmlProjectResourceRegistrar registrar = new MuleXmlProjectResourceRegistrar();
-        ApplicationProperties applicationProperties = new ApplicationProperties();
-        applicationProperties.setDefaultBasePackage("com.example.javadsl");
 
         ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
                 .addProjectResource("src/main/resources/mule-simple-amqp-flow.xml", muleXml)
@@ -120,10 +117,6 @@ public class MuleToJavaDSLMultipleTest extends JavaDSLActionBaseTest {
 
     @Test
     public void generatesAmqpDSLStatements() {
-
-        MuleXmlProjectResourceRegistrar registrar = new MuleXmlProjectResourceRegistrar();
-        ApplicationProperties applicationProperties = new ApplicationProperties();
-        applicationProperties.setDefaultBasePackage("com.example.javadsl");
 
         ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
                 .addProjectResource("src/main/resources/mule-simple-amqp-flow.xml", muleInboundOutboundXml)
@@ -163,10 +156,6 @@ public class MuleToJavaDSLMultipleTest extends JavaDSLActionBaseTest {
 
     @Test
     public void generatesAMQPConnectorBean() {
-
-        MuleXmlProjectResourceRegistrar registrar = new MuleXmlProjectResourceRegistrar();
-        ApplicationProperties applicationProperties = new ApplicationProperties();
-        applicationProperties.setDefaultBasePackage("com.example.javadsl");
 
         ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
                 .addProjectResource("src/main/resources/mule-simple-amqp-flow.xml", muleInboundOutboundXml)

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLMultipleTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLMultipleTest.java
@@ -18,49 +18,12 @@ package org.springframework.sbm.mule.actions;
 import org.junit.jupiter.api.Test;
 import org.springframework.sbm.boot.properties.api.SpringBootApplicationProperties;
 import org.springframework.sbm.boot.properties.search.SpringBootApplicationPropertiesResourceListFilter;
-import org.springframework.sbm.engine.context.ProjectContext;
-import org.springframework.sbm.mule.resource.MuleXml;
-import org.springframework.sbm.mule.resource.MuleXmlProjectResourceFilter;
-import org.springframework.sbm.mule.resource.MuleXmlProjectResourceRegistrar;
-import org.springframework.sbm.project.resource.ApplicationProperties;
-import org.springframework.sbm.project.resource.TestProjectContext;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MuleToJavaDSLMultipleTest extends JavaDSLActionBaseTest {
-    private final static String muleXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-            "\n" +
-            "<mule xmlns:amqp=\"http://www.mulesoft.org/schema/mule/amqp\" xmlns:http=\"http://www.mulesoft.org/schema/mule/http\" xmlns=\"http://www.mulesoft.org/schema/mule/core\" xmlns:doc=\"http://www.mulesoft.org/schema/mule/documentation\"\n" +
-            "xmlns:spring=\"http://www.springframework.org/schema/beans\" \n" +
-            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
-            "xsi:schemaLocation=\"http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd\n" +
-            "http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd\n" +
-            "http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd\n" +
-            "http://www.mulesoft.org/schema/mule/amqp http://www.mulesoft.org/schema/mule/amqp/current/mule-amqp.xsd\">\n" +
-            "<amqp:connector name=\"amqpConnector\"\n" +
-            "  host=\"localhost\"\n" +
-            "  port=\"5672\"\n" +
-            "  username=\"guest\"\n" +
-            "  password=\"guest\"\n" +
-            "  doc:name=\"AMQP-0-9 Connector\"\n" +
-            "   />\n" +
-            "<flow name=\"amqp-muleFlow\">\n" +
-            "<amqp:inbound-endpoint \n" +
-            "queueName=\"sbm-integration-queue-one\"\n" +
-            "connector-ref=\"amqpConnector\"\n" +
-            "/>\n" +
-            "<!-- <http:listener config-ref=\"HTTP_Listener_Configuration\" path=\"/test\" allowedMethods=\"POST\" doc:name=\"Recieve HTTP request\"/> -->\n" +
-            "<logger message=\"payload to be sent: #[new String(payload)]\" level=\"INFO\" doc:name=\"Log the message content to be sent\"/>\n" +
-            "        <amqp:outbound-endpoint \n" +
-            "        exchangeName=\"sbm-integration-exchange\" \n" +
-            "        routingKey=\"sbm-integration-queue-two\"\n" +
-            "        responseTimeout=\"10000\"  \n" +
-            "        doc:name=\"Send to AMQP queue\"\n" +
-            "        />\n" +
-            "</flow>\n" +
-            "</mule>\n";
 
     private static final String muleInboundOutboundXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
             "\n" +
@@ -95,22 +58,21 @@ public class MuleToJavaDSLMultipleTest extends JavaDSLActionBaseTest {
             "</mule>\n";
 
     @Test
-    public void generatesAmqpDSLStatements() {
-
-        ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
-                .addProjectResource("src/main/resources/mule-simple-amqp-flow.xml", muleInboundOutboundXml)
-                .withApplicationProperties(applicationProperties)
-                .withBuildFileHavingDependencies(
-                        "org.springframework.boot:spring-boot-starter-web:2.5.5",
-                        "org.springframework.boot:spring-boot-starter-integration:2.5.5",
-                        "org.springframework.integration:spring-integration-amqp:5.4.4",
-                        "org.springframework.integration:spring-integration-stream:5.4.4",
-                        "org.springframework.integration:spring-integration-http:5.4.4"
-                )
-                .addRegistrar(registrar)
-                .build();
-        myAction.apply(projectContext);
+    public void generatesAmqpDSLStatementsAndConfigurations() {
+        addXMLFileToResource(muleInboundOutboundXml);
+        runAction();
         assertThat(projectContext.getProjectJavaSources().list()).hasSize(1);
+        List<SpringBootApplicationProperties> springBootApplicationProperties = projectContext.search(new SpringBootApplicationPropertiesResourceListFilter());
+        assertThat(springBootApplicationProperties).hasSize(1);
+
+        SpringBootApplicationProperties properties = springBootApplicationProperties.get(0);
+
+
+        String applicationPropertiesContent = properties.print();
+        assertThat(applicationPropertiesContent).isEqualTo(
+                "spring.rabbitmq.host=localhost\n" +
+                        "spring.rabbitmq.port=5672"
+        );
         assertThat(projectContext.getProjectJavaSources().list().get(0).print())
                 .isEqualTo(
                         "package com.example.javadsl;\n" +
@@ -131,59 +93,5 @@ public class MuleToJavaDSLMultipleTest extends JavaDSLActionBaseTest {
                                 "                .handle(Amqp.outboundAdapter(rabbitTemplate).exchangeName(\"sbm-integration-exchange\").routingKey(\"sbm-integration-queue-two\"))\n" +
                                 "                .get();\n" +
                                 "    }}");
-    }
-
-    @Test
-    public void generatesAMQPConnectorBean() {
-
-        ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
-                .addProjectResource("src/main/resources/mule-simple-amqp-flow.xml", muleInboundOutboundXml)
-                .withApplicationProperties(applicationProperties)
-                .withBuildFileHavingDependencies(
-                        "org.springframework.boot:spring-boot-starter-web:2.5.5",
-                        "org.springframework.boot:spring-boot-starter-integration:2.5.5",
-                        "org.springframework.integration:spring-integration-amqp:5.4.4",
-                        "org.springframework.integration:spring-integration-stream:5.4.4",
-                        "org.springframework.integration:spring-integration-http:5.4.4"
-                )
-                .addRegistrar(registrar)
-                .build();
-
-
-        myAction.apply(projectContext);
-
-        assertThat(projectContext.getProjectJavaSources().list()).hasSize(1);
-        List<SpringBootApplicationProperties> springBootApplicationProperties = projectContext.search(new SpringBootApplicationPropertiesResourceListFilter());
-        assertThat(springBootApplicationProperties).hasSize(1);
-
-        SpringBootApplicationProperties properties = springBootApplicationProperties.get(0);
-
-
-        String applicationPropertiesContent = properties.print();
-        assertThat(applicationPropertiesContent).isEqualTo(
-                "spring.rabbitmq.host=localhost\n" +
-                "spring.rabbitmq.port=5672"
-        );
-
-        assertThat(projectContext.getProjectJavaSources().list().get(0).print()).isEqualTo(
-                "package com.example.javadsl;\n" +
-                        "import org.springframework.amqp.rabbit.core.RabbitTemplate;\n" +
-                        "import org.springframework.context.annotation.Bean;\n" +
-                        "import org.springframework.context.annotation.Configuration;\n" +
-                        "import org.springframework.integration.amqp.dsl.Amqp;\n" +
-                        "import org.springframework.integration.dsl.IntegrationFlow;\n" +
-                        "import org.springframework.integration.dsl.IntegrationFlows;\n" +
-                        "import org.springframework.integration.handler.LoggingHandler;\n" +
-                        "\n" +
-                        "@Configuration\n" +
-                        "public class FlowConfigurations {\n" +
-                        "    @Bean\n" +
-                        "    IntegrationFlow amqp_muleFlow(org.springframework.amqp.rabbit.core.RabbitTemplate rabbitTemplate, org.springframework.amqp.rabbit.connection.ConnectionFactory connectionFactory) {\n" +
-                        "        return IntegrationFlows.from(Amqp.inboundAdapter(connectionFactory, \"sbm-integration-queue-one\"))\n" +
-                        "                .log(LoggingHandler.Level.INFO, \"payload to be sent: #[new String(payload)]\")\n" +
-                        "                .handle(Amqp.outboundAdapter(rabbitTemplate).exchangeName(\"sbm-integration-exchange\").routingKey(\"sbm-integration-queue-two\"))\n" +
-                        "                .get();\n" +
-                        "    }}"
-        );
     }
 }

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLMultipleTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLMultipleTest.java
@@ -95,27 +95,6 @@ public class MuleToJavaDSLMultipleTest extends JavaDSLActionBaseTest {
             "</mule>\n";
 
     @Test
-    public void detectsMuleXMLFiles() {
-
-        ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
-                .addProjectResource("src/main/resources/mule-simple-amqp-flow.xml", muleXml)
-                .withApplicationProperties(applicationProperties)
-                .withBuildFileHavingDependencies(
-                        "org.springframework.boot:spring-boot-starter-web:2.5.5",
-                        "org.springframework.boot:spring-boot-starter-integration:2.5.5",
-                        "org.springframework.integration:spring-integration-amqp:5.4.4",
-                        "org.springframework.integration:spring-integration-stream:5.4.4",
-                        "org.springframework.integration:spring-integration-http:5.4.4"
-                )
-                .addRegistrar(registrar)
-                .build();
-
-        List<MuleXml> muleSearch = projectContext.search(new MuleXmlProjectResourceFilter());
-
-        assertThat(projectContext.getProjectResources().list()).hasSize(2);
-    }
-
-    @Test
     public void generatesAmqpDSLStatements() {
 
         ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLSetPropertyTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLSetPropertyTest.java
@@ -42,10 +42,6 @@ public class MuleToJavaDSLSetPropertyTest extends JavaDSLActionBaseTest {
     @Test
     public void shouldGenerateSetPropertyStatements() {
 
-        MuleXmlProjectResourceRegistrar registrar = new MuleXmlProjectResourceRegistrar();
-        ApplicationProperties applicationProperties = new ApplicationProperties();
-        applicationProperties.setDefaultBasePackage("com.example.javadsl");
-
         ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
                 .addProjectResource("src/main/resources/mule-set-property-flow.xml", muleXml)
                 .withApplicationProperties(applicationProperties)

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLSetPropertyTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLSetPropertyTest.java
@@ -17,10 +17,6 @@
 package org.springframework.sbm.mule.actions;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.sbm.engine.context.ProjectContext;
-import org.springframework.sbm.mule.resource.MuleXmlProjectResourceRegistrar;
-import org.springframework.sbm.project.resource.ApplicationProperties;
-import org.springframework.sbm.project.resource.TestProjectContext;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,20 +37,8 @@ public class MuleToJavaDSLSetPropertyTest extends JavaDSLActionBaseTest {
 
     @Test
     public void shouldGenerateSetPropertyStatements() {
-
-        ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
-                .addProjectResource("src/main/resources/mule-set-property-flow.xml", muleXml)
-                .withApplicationProperties(applicationProperties)
-                .withBuildFileHavingDependencies(
-                        "org.springframework:spring-context:5.3.1",
-                        "org.springframework:spring-beans:5.3.1",
-                        "org.springframework.integration:spring-integration-core:5.5.8",
-                        "org.springframework.integration:spring-integration-http:5.5.8",
-                        "org.springframework.boot:spring-boot-starter-integration:2.6.3"
-                )
-                .addRegistrar(registrar)
-                .build();
-        myAction.apply(projectContext);
+        addXMLFileToResource(muleXml);
+        runAction();
         assertThat(projectContext.getProjectJavaSources().list()).hasSize(1);
         assertThat(projectContext.getProjectJavaSources().list().get(0).print())
                 .isEqualTo(

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLTransformerTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLTransformerTest.java
@@ -15,30 +15,9 @@
  */
 package org.springframework.sbm.mule.actions;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.sbm.engine.context.ProjectContext;
-import org.springframework.sbm.mule.actions.javadsl.translators.MuleComponentToSpringIntegrationDslTranslator;
-import org.springframework.sbm.mule.actions.javadsl.translators.common.ExpressionLanguageTranslator;
-import org.springframework.sbm.mule.actions.javadsl.translators.core.TransformerTranslator;
-import org.springframework.sbm.mule.actions.javadsl.translators.http.HttpListenerConfigTypeAdapter;
-import org.springframework.sbm.mule.actions.javadsl.translators.http.HttpListenerTranslator;
-import org.springframework.sbm.mule.actions.javadsl.translators.logging.LoggingTranslator;
-import org.springframework.sbm.mule.api.MuleMigrationContextFactory;
-import org.springframework.sbm.mule.api.toplevel.FlowTopLevelElementFactory;
-import org.springframework.sbm.mule.api.toplevel.SubflowTopLevelElementFactory;
-import org.springframework.sbm.mule.api.toplevel.TopLevelElementFactory;
-import org.springframework.sbm.mule.api.toplevel.configuration.ConfigurationTypeAdapterFactory;
-import org.springframework.sbm.mule.api.toplevel.configuration.MuleConfigurationsExtractor;
-import org.springframework.sbm.mule.resource.MuleXmlProjectResourceRegistrar;
-import org.springframework.sbm.project.resource.ApplicationProperties;
-import org.springframework.sbm.project.resource.TestProjectContext;
-
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 public class MuleToJavaDSLTransformerTest extends JavaDSLActionBaseTest {
     private final static String muleXmlHttp = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
@@ -64,20 +43,8 @@ public class MuleToJavaDSLTransformerTest extends JavaDSLActionBaseTest {
 
     @Test
     public void shouldGenerateJavaDSLForFlowHttpMuleTag() {
-
-        ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
-                .addProjectResource("src/main/resources/mule-simple-http-flow.xml", muleXmlHttp)
-                .withApplicationProperties(applicationProperties)
-                .withBuildFileHavingDependencies(
-                        "org.springframework:spring-context:5.3.1",
-                        "org.springframework:spring-beans:5.3.1",
-                        "org.springframework.integration:spring-integration-core:5.5.8",
-                        "org.springframework.integration:spring-integration-http:5.5.8",
-                        "org.springframework.boot:spring-boot-starter-integration:2.6.3"
-                )
-                .addRegistrar(registrar)
-                .build();
-        myAction.apply(projectContext);
+        addXMLFileToResource(muleXmlHttp);
+        runAction();
         assertThat(projectContext.getProjectJavaSources().list().size()).isEqualTo(1);
         assertThat(projectContext.getProjectJavaSources().list().get(0).print())
                 .isEqualTo("package com.example.javadsl;\n" +

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLTransformerTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLTransformerTest.java
@@ -64,9 +64,6 @@ public class MuleToJavaDSLTransformerTest extends JavaDSLActionBaseTest {
 
     @Test
     public void shouldGenerateJavaDSLForFlowHttpMuleTag() {
-        MuleXmlProjectResourceRegistrar registrar = new MuleXmlProjectResourceRegistrar();
-        ApplicationProperties applicationProperties = new ApplicationProperties();
-        applicationProperties.setDefaultBasePackage("com.example.javadsl");
 
         ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
                 .addProjectResource("src/main/resources/mule-simple-http-flow.xml", muleXmlHttp)

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLWmqTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLWmqTest.java
@@ -50,9 +50,6 @@ public class MuleToJavaDSLWmqTest extends JavaDSLActionBaseTest {
 
     @Test
     public void shouldGenerateWmqOutboundStatements() {
-        MuleXmlProjectResourceRegistrar registrar = new MuleXmlProjectResourceRegistrar();
-        ApplicationProperties applicationProperties = new ApplicationProperties();
-        applicationProperties.setDefaultBasePackage("com.example.javadsl");
 
         ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
                 .addProjectResource("src/main/resources/mule-set-property-flow.xml", muleXml)

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLWmqTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLWmqTest.java
@@ -19,11 +19,7 @@ package org.springframework.sbm.mule.actions;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.SourceFile;
 import org.springframework.sbm.build.api.Dependency;
-import org.springframework.sbm.engine.context.ProjectContext;
-import org.springframework.sbm.mule.resource.MuleXmlProjectResourceRegistrar;
-import org.springframework.sbm.project.resource.ApplicationProperties;
 import org.springframework.sbm.project.resource.RewriteSourceFileHolder;
-import org.springframework.sbm.project.resource.TestProjectContext;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -50,19 +46,8 @@ public class MuleToJavaDSLWmqTest extends JavaDSLActionBaseTest {
 
     @Test
     public void shouldGenerateWmqOutboundStatements() {
-
-        ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
-                .addProjectResource("src/main/resources/mule-set-property-flow.xml", muleXml)
-                .withApplicationProperties(applicationProperties)
-                .withBuildFileHavingDependencies(
-                        "org.springframework:spring-context:5.3.1",
-                        "org.springframework:spring-beans:5.3.1",
-                        "org.springframework.integration:spring-integration-core:5.5.8",
-                        "org.springframework.boot:spring-boot-starter-integration:2.6.3"
-                )
-                .addRegistrar(registrar)
-                .build();
-        myAction.apply(projectContext);
+        addXMLFileToResource(muleXml);
+        runAction();
         assertThat(projectContext.getProjectJavaSources().list()).hasSize(1);
         assertThat(projectContext.getProjectJavaSources().list().get(0).print())
                 .isEqualTo(

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MultipleFlowsTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MultipleFlowsTest.java
@@ -16,17 +16,12 @@
 package org.springframework.sbm.mule.actions;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.sbm.engine.context.ProjectContext;
-import org.springframework.sbm.mule.resource.MuleXmlProjectResourceRegistrar;
-import org.springframework.sbm.project.resource.ApplicationProperties;
-import org.springframework.sbm.project.resource.TestProjectContext;
-
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MultipleFlowsTest extends JavaDSLActionBaseTest {
 
-    private final static String  muleMultiFlow = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+    private final static String muleMultiFlow = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
             "\n" +
             "<mule xmlns:dw=\"http://www.mulesoft.org/schema/mule/ee/dw\" xmlns:metadata=\"http://www.mulesoft.org/schema/mule/metadata\" xmlns:amqp=\"http://www.mulesoft.org/schema/mule/amqp\" xmlns:http=\"http://www.mulesoft.org/schema/mule/http\" xmlns=\"http://www.mulesoft.org/schema/mule/core\" xmlns:doc=\"http://www.mulesoft.org/schema/mule/documentation\"\n" +
             "xmlns:spring=\"http://www.springframework.org/schema/beans\" \n" +
@@ -47,19 +42,8 @@ public class MultipleFlowsTest extends JavaDSLActionBaseTest {
 
     @Test
     public void shouldTranslateSubflow() {
-        ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
-                .addProjectResource("src/main/resources/mule-multi-flow.xml", muleMultiFlow)
-                .addRegistrar(registrar)
-                .withApplicationProperties(applicationProperties)
-                .withBuildFileHavingDependencies(
-                        "org.springframework.boot:spring-boot-starter-web:2.5.5",
-                        "org.springframework.boot:spring-boot-starter-integration:2.5.5",
-                        "org.springframework.integration:spring-integration-amqp:5.4.4",
-                        "org.springframework.integration:spring-integration-stream:5.4.4",
-                        "org.springframework.integration:spring-integration-http:5.4.4"
-                )
-                .build();
-        myAction.apply(projectContext);
+        addXMLFileToResource(muleMultiFlow);
+        runAction();
         assertThat(projectContext.getProjectJavaSources().list().size()).isEqualTo(1);
 
         assertThat(projectContext.getProjectJavaSources().list().get(0).print())

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MultipleFlowsTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MultipleFlowsTest.java
@@ -47,10 +47,6 @@ public class MultipleFlowsTest extends JavaDSLActionBaseTest {
 
     @Test
     public void shouldTranslateSubflow() {
-        MuleXmlProjectResourceRegistrar registrar = new MuleXmlProjectResourceRegistrar();
-        ApplicationProperties applicationProperties = new ApplicationProperties();
-        applicationProperties.setDefaultBasePackage("com.example.javadsl");
-
         ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
                 .addProjectResource("src/main/resources/mule-multi-flow.xml", muleMultiFlow)
                 .addRegistrar(registrar)

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/SubflowsTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/SubflowsTest.java
@@ -16,8 +16,6 @@
 package org.springframework.sbm.mule.actions;
 
 import org.springframework.sbm.engine.context.ProjectContext;
-import org.springframework.sbm.mule.resource.MuleXmlProjectResourceRegistrar;
-import org.springframework.sbm.project.resource.ApplicationProperties;
 import org.springframework.sbm.project.resource.TestProjectContext;
 import org.junit.jupiter.api.Test;
 
@@ -94,19 +92,9 @@ public class SubflowsTest extends JavaDSLActionBaseTest {
 
     @Test
     public void generatedFlowShouldHaveMethodParams() {
-        ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
-                .addProjectResource("src/main/resources/mule-rabbit.xml", subflowWithRabbit)
-                .addRegistrar(registrar)
-                .withApplicationProperties(applicationProperties)
-                .withBuildFileHavingDependencies(
-                        "org.springframework.boot:spring-boot-starter-web:2.5.5",
-                        "org.springframework.boot:spring-boot-starter-integration:2.5.5",
-                        "org.springframework.integration:spring-integration-amqp:5.4.4",
-                        "org.springframework.integration:spring-integration-stream:5.4.4",
-                        "org.springframework.integration:spring-integration-http:5.4.4"
-                )
-                .build();
-        myAction.apply(projectContext);
+
+        addXMLFileToResource(subflowWithRabbit);
+        runAction();
         assertThat(projectContext.getProjectJavaSources().list().size()).isEqualTo(1);
         assertThat(projectContext.getProjectJavaSources().list().get(0).print())
                 .isEqualTo("package com.example.javadsl;\n" +
@@ -139,19 +127,9 @@ public class SubflowsTest extends JavaDSLActionBaseTest {
 
     @Test
     public void shouldTranslateSubflowWithUnknownElements() {
-        ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
-                .addProjectResource("src/main/resources/mule-rabbit.xml", subflowUnknown)
-                .addRegistrar(registrar)
-                .withApplicationProperties(applicationProperties)
-                .withBuildFileHavingDependencies(
-                        "org.springframework.boot:spring-boot-starter-web:2.5.5",
-                        "org.springframework.boot:spring-boot-starter-integration:2.5.5",
-                        "org.springframework.integration:spring-integration-amqp:5.4.4",
-                        "org.springframework.integration:spring-integration-stream:5.4.4",
-                        "org.springframework.integration:spring-integration-http:5.4.4"
-                )
-                .build();
-        myAction.apply(projectContext);
+        addXMLFileToResource(subflowUnknown);
+        runAction();
+
         assertThat(projectContext.getProjectJavaSources().list().size()).isEqualTo(1);
         assertThat(projectContext.getProjectJavaSources().list().get(0).print())
                 .isEqualTo("package com.example.javadsl;\n" +
@@ -179,6 +157,5 @@ public class SubflowsTest extends JavaDSLActionBaseTest {
                         "        };\n" +
                         "    }}"
                 );
-
     }
 }

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/SubflowsTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/SubflowsTest.java
@@ -94,10 +94,6 @@ public class SubflowsTest extends JavaDSLActionBaseTest {
 
     @Test
     public void generatedFlowShouldHaveMethodParams() {
-        MuleXmlProjectResourceRegistrar registrar = new MuleXmlProjectResourceRegistrar();
-        ApplicationProperties applicationProperties = new ApplicationProperties();
-        applicationProperties.setDefaultBasePackage("com.example.javadsl");
-
         ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
                 .addProjectResource("src/main/resources/mule-rabbit.xml", subflowWithRabbit)
                 .addRegistrar(registrar)
@@ -143,10 +139,6 @@ public class SubflowsTest extends JavaDSLActionBaseTest {
 
     @Test
     public void shouldTranslateSubflowWithUnknownElements() {
-        MuleXmlProjectResourceRegistrar registrar = new MuleXmlProjectResourceRegistrar();
-        ApplicationProperties applicationProperties = new ApplicationProperties();
-        applicationProperties.setDefaultBasePackage("com.example.javadsl");
-
         ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
                 .addProjectResource("src/main/resources/mule-rabbit.xml", subflowUnknown)
                 .addRegistrar(registrar)

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/UnknownFlowTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/UnknownFlowTest.java
@@ -16,10 +16,6 @@
 package org.springframework.sbm.mule.actions;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.sbm.engine.context.ProjectContext;
-import org.springframework.sbm.mule.resource.MuleXmlProjectResourceRegistrar;
-import org.springframework.sbm.project.resource.ApplicationProperties;
-import org.springframework.sbm.project.resource.TestProjectContext;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,18 +34,11 @@ public class UnknownFlowTest extends JavaDSLActionBaseTest {
 
     @Test
     public void shouldTranslateUnknownFlow() {
-        ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
-                .addProjectResource("src/main/resources/mule-multi-flow.xml", muleMultiFlow)
-                .addRegistrar(registrar)
-                .withApplicationProperties(applicationProperties)
-                .withBuildFileHavingDependencies(
-                        "org.springframework.boot:spring-boot-starter-integration:2.5.5",
-                        "org.springframework.integration:spring-integration-stream:5.4.4"
-                )
-                .build();
-        myAction.apply(projectContext);
-        assertThat(projectContext.getProjectJavaSources().list().size()).isEqualTo(1);
 
+        addXMLFileToResource(muleMultiFlow);
+        runAction();
+
+        assertThat(projectContext.getProjectJavaSources().list().size()).isEqualTo(1);
 
         assertThat(projectContext.getProjectJavaSources().list().get(0).print())
                 .isEqualTo("package com.example.javadsl;\n" +

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/UnknownFlowTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/UnknownFlowTest.java
@@ -38,10 +38,6 @@ public class UnknownFlowTest extends JavaDSLActionBaseTest {
 
     @Test
     public void shouldTranslateUnknownFlow() {
-        MuleXmlProjectResourceRegistrar registrar = new MuleXmlProjectResourceRegistrar();
-        ApplicationProperties applicationProperties = new ApplicationProperties();
-        applicationProperties.setDefaultBasePackage("com.example.javadsl");
-
         ProjectContext projectContext = TestProjectContext.buildProjectContext(eventPublisher)
                 .addProjectResource("src/main/resources/mule-multi-flow.xml", muleMultiFlow)
                 .addRegistrar(registrar)

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/api/MuleConfigurationsExtractorTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/api/MuleConfigurationsExtractorTest.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MuleConfigurationsExtractorTest {
-    private String muleXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+    private static final String muleXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
             "\n" +
             "<mule xmlns:amqp=\"http://www.mulesoft.org/schema/mule/amqp\" xmlns:http=\"http://www.mulesoft.org/schema/mule/http\" xmlns=\"http://www.mulesoft.org/schema/mule/core\" xmlns:doc=\"http://www.mulesoft.org/schema/mule/documentation\"\n" +
             "xmlns:spring=\"http://www.springframework.org/schema/beans\" \n" +


### PR DESCRIPTION
I have moved setting up project context code in tests to base class further reducing code duplicates. Removing further **381** lines of code. 

This refactor also increases test speed. Averaged over 3 tries tests run **twice** as fast
 | Branch |Time taken to run tests (Avg. over 3 tries) |
| --- | ----------- |
| Main | 1m |
| this branch | 30 sec |

This speed is achieved by removing calls to .withBuildFileHavingDependencies() function where the action should automatically add the required dependency 