### PR TITLE
API router kit Component imports Required dependencies

### DIFF
--- a/applications/spring-shell/src/test/java/org/springframework/sbm/BootifySimpleMuleAppIntegrationTest.java
+++ b/applications/spring-shell/src/test/java/org/springframework/sbm/BootifySimpleMuleAppIntegrationTest.java
@@ -42,7 +42,6 @@ public class BootifySimpleMuleAppIntegrationTest extends IntegrationTestBaseClas
 
     private static final String FIRST_QUEUE_NAME = "sbm-integration-queue-one";
     private static final String SECOND_QUEUE_NAME = "sbm-integration-queue-two";
-    private static final ConnectionFactory CONNECTION_FACTORY = new ConnectionFactory();
     private String messageContent;
     private final RestTemplate restTemplate = new RestTemplate();
 

--- a/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/javadsl/translators/http/HttpListenerTranslator.java
+++ b/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/javadsl/translators/http/HttpListenerTranslator.java
@@ -35,10 +35,11 @@ import java.util.Set;
 @Slf4j
 public class HttpListenerTranslator implements MuleComponentToSpringIntegrationDslTranslator<ListenerType> {
 
-    private String javaDslHttpListenerTemplate = "return IntegrationFlows.from(Http.inboundChannelAdapter(\"${path}\")).handle((p, h) -> p)";
+    private final static String javaDslHttpListenerTemplate =
+            "return IntegrationFlows.from(Http.inboundChannelAdapter(\"${path}\")).handle((p, h) -> p)";
 
     @Override
-    public Class getSupportedMuleType() {
+    public Class<ListenerType> getSupportedMuleType() {
         return ListenerType.class;
     }
 
@@ -54,8 +55,10 @@ public class HttpListenerTranslator implements MuleComponentToSpringIntegrationD
             log.error("Path attribute of <http:listener> must not be set.");
         }
 
-        String snippet = javaDslHttpListenerTemplate.replace("${path}", path);
-        DslSnippet dslSnippet = new DslSnippet(snippet,
+        String snippet = path == null ? javaDslHttpListenerTemplate :
+                javaDslHttpListenerTemplate.replace("${path}", path);
+
+        return new DslSnippet(snippet,
                 Set.of("org.springframework.context.annotation.Bean",
                         "org.springframework.context.annotation.Configuration",
                         "org.springframework.integration.dsl.IntegrationFlow",
@@ -69,6 +72,5 @@ public class HttpListenerTranslator implements MuleComponentToSpringIntegrationD
                         "org.springframework.integration:spring-integration-http:5.4.4"
                 ),
                 Collections.emptySet());
-        return dslSnippet;
     }
 }

--- a/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/api/toplevel/ApiRouterKitFlowTopLevelElement.java
+++ b/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/api/toplevel/ApiRouterKitFlowTopLevelElement.java
@@ -68,6 +68,13 @@ public class ApiRouterKitFlowTopLevelElement extends AbstractTopLevelElement {
         return requiredImports;
     }
 
+    @Override
+    public Set<String> getRequiredDependencies() {
+        Set<String> requiredDependencies = super.getRequiredDependencies();
+        requiredDependencies.add("org.springframework.integration:spring-integration-http:5.4.4");
+        return requiredDependencies;
+    }
+
     public static boolean isApiRouterKitName(String name) {
         return name.matches(apiRoutingKitNamingPattern);
     }

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/JavaDSLActionBaseTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/JavaDSLActionBaseTest.java
@@ -44,7 +44,6 @@ import org.springframework.sbm.mule.resource.MuleXmlProjectResourceRegistrar;
 import org.springframework.sbm.project.resource.ApplicationProperties;
 import org.springframework.sbm.project.resource.TestProjectContext;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
 

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/JavaDSLActionBaseTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/JavaDSLActionBaseTest.java
@@ -103,17 +103,6 @@ public class JavaDSLActionBaseTest {
         ;
     }
 
-    protected void setupProjectDependencies(String... dependencies) {
-
-        if (dependencies == null || dependencies.length == 0) {
-            return;
-        }
-
-        projectContextBuilder.withBuildFileHavingDependencies(
-                dependencies
-        );
-    }
-
     protected void addXMLFileToResource(String... xmlFile) {
 
         IntStream.range(0, xmlFile.length)

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLApiKitTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLApiKitTest.java
@@ -33,10 +33,6 @@ public class MuleToJavaDSLApiKitTest extends JavaDSLActionBaseTest {
     @Test
     public void generatesApiKitDSLStatements() {
         addXMLFileToResource(muleXml);
-        //TODO: This requirement may be hiding a bug
-        setupProjectDependencies(
-                "org.springframework.integration:spring-integration-http:5.4.4"
-        );
         runAction();
         assertThat(projectContext.getProjectJavaSources().list()).hasSize(1);
         assertThat(projectContext.getProjectJavaSources().list().get(0).print())


### PR DESCRIPTION
When using API router kit component, it was not bringing in spring-integration-http import automatically. now it does.

I have also made general clean up