### PR TITLE
Null pointer exception fix in DWL Transformation

### DIFF
--- a/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/javadsl/translators/dwl/DwlTransformTranslator.java
+++ b/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/javadsl/translators/dwl/DwlTransformTranslator.java
@@ -25,6 +25,7 @@ import org.springframework.stereotype.Component;
 
 import javax.xml.namespace.QName;
 import java.util.Collections;
+import java.util.Set;
 
 @Component
 public class DwlTransformTranslator implements MuleComponentToSpringIntegrationDslTranslator<TransformMessageType> {
@@ -57,11 +58,20 @@ public class DwlTransformTranslator implements MuleComponentToSpringIntegrationD
             String flowName
     ) {
 
-        if (isComponentReferencingAnExternalFile(component)) {
-            return formExternalFileBasedDSLSnippet(component);
+        if (component.getSetPayload() != null) {
+            if (isComponentReferencingAnExternalFile(component)) {
+                return formExternalFileBasedDSLSnippet(component);
+            }
+
+            return formEmbeddedDWLBasedDSLSnippet(component, Helper.sanitizeForBeanMethodName(flowName));
         }
 
-        return formEmbeddedDWLBasedDSLSnippet(component, Helper.sanitizeForBeanMethodName(flowName));
+        return noSupportDslSnippet();
+    }
+
+    private DslSnippet noSupportDslSnippet() {
+        String noSupport = "// FIXME: No support for following DW transformation: <dw:set-property/> <dw:set-session-variable /> <dw:set-variable />";
+        return new DslSnippet(noSupport, Set.of(), Set.of(), Set.of());
     }
 
     private DslSnippet formEmbeddedDWLBasedDSLSnippet(TransformMessageType component, String flowName) {

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLDwlTransformTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLDwlTransformTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class MuleToJavaDSLDwlTransformTest extends JavaDSLActionBaseTest {
 
-    private static final String muleXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+    private static final String muleXmlSetPayload = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
             "\n" +
             "<mule xmlns:dw=\"http://www.mulesoft.org/schema/mule/ee/dw\" xmlns:http=\"http://www.mulesoft.org/schema/mule/http\" xmlns=\"http://www.mulesoft.org/schema/mule/core\" xmlns:doc=\"http://www.mulesoft.org/schema/mule/documentation\"\n" +
             "    xmlns:spring=\"http://www.springframework.org/schema/beans\" \n" +
@@ -78,8 +78,8 @@ public class MuleToJavaDSLDwlTransformTest extends JavaDSLActionBaseTest {
             "</mule>";
 
     @Test
-    public void shouldTranslateDwlTransformation() {
-        addXMLFileToResource(muleXml);
+    public void shouldTranslateDwlTransformationWithSetPayload() {
+        addXMLFileToResource(muleXmlSetPayload);
         runAction();
         assertThat(projectContext.getProjectJavaSources().list()).hasSize(2);
         assertThat(projectContext.getProjectJavaSources().list().get(0).print())
@@ -127,7 +127,7 @@ public class MuleToJavaDSLDwlTransformTest extends JavaDSLActionBaseTest {
     }
 
     @Test
-    public void shouldTransformDWLWithFile() {
+    public void shouldTransformDWLWithFileWithSetPayload() {
         addXMLFileToResource(dwlXMLWithExternalFile);
         runAction();
         assertThat(projectContext.getProjectJavaSources().list()).hasSize(2);
@@ -167,5 +167,58 @@ public class MuleToJavaDSLDwlTransformTest extends JavaDSLActionBaseTest {
                                 "        return new MapClientRiskRatingResponseTransform();\n" +
                                 "    }\n" +
                                 "}");
+    }
+
+    @Test
+    public void shouldTranslateDWLTransformationWithOnlyOneSetVariable() {
+        String muleXMLSetVariable = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "\n" +
+                "<mule xmlns:dw=\"http://www.mulesoft.org/schema/mule/ee/dw\" xmlns:http=\"http://www.mulesoft.org/schema/mule/http\" xmlns=\"http://www.mulesoft.org/schema/mule/core\" xmlns:doc=\"http://www.mulesoft.org/schema/mule/documentation\"\n" +
+                "    xmlns:spring=\"http://www.springframework.org/schema/beans\" \n" +
+                "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+                "    xsi:schemaLocation=\"http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd\n" +
+                "http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd\n" +
+                "http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd\n" +
+                "http://www.mulesoft.org/schema/mule/ee/dw http://www.mulesoft.org/schema/mule/ee/dw/current/dw.xsd\">\n" +
+                "    <flow name=\"dwlFlow\">\n" +
+                "        <http:listener config-ref=\"HTTP_Listener_Configuration\" path=\"/dwl\" doc:name=\"HTTP\"/>\n" +
+                "    \n" +
+                "        <dw:transform-message doc:name=\"action transform\">\n" +
+                "        <dw:set-variable variableName=\"temp\"><![CDATA[%dw 1.0\n" +
+                "%output application/json\n" +
+                "---\n" +
+                "{\n" +
+                "    action_Code: 10,\n" +
+                "    returnCode:  20\n" +
+                "}]]>\n" +
+                "        \n" +
+                "        </dw:set-variable>\n" +
+                "        </dw:transform-message>\n" +
+                "        \n" +
+                "         <logger message=\"Hello World:  #[flowVars.temp]\" level=\"INFO\" doc:name=\"Log the message content to be sent\"/>\n" +
+                "    </flow>\n" +
+                "</mule>";
+        addXMLFileToResource(muleXMLSetVariable);
+        runAction();
+        assertThat(projectContext.getProjectJavaSources().list()).hasSize(1);
+        assertThat(projectContext.getProjectJavaSources().list().get(0).print())
+                .isEqualTo(
+                        "package com.example.javadsl;\n" +
+                                "import org.springframework.context.annotation.Bean;\n" +
+                                "import org.springframework.context.annotation.Configuration;\n" +
+                                "import org.springframework.integration.dsl.IntegrationFlow;\n" +
+                                "import org.springframework.integration.dsl.IntegrationFlows;\n" +
+                                "import org.springframework.integration.handler.LoggingHandler;\n" +
+                                "import org.springframework.integration.http.dsl.Http;\n" +
+                                "\n" +
+                                "@Configuration\n" +
+                                "public class FlowConfigurations {\n" +
+                                "    @Bean\n" +
+                                "    IntegrationFlow dwlFlow() {\n" +
+                                "        return IntegrationFlows.from(Http.inboundChannelAdapter(\"/dwl\")).handle((p, h) -> p)\n" +
+                                "                // FIXME: No support for following DW transformation: <dw:set-property/> <dw:set-session-variable /> <dw:set-variable />\n" +
+                                "                .log(LoggingHandler.Level.INFO, \"Hello World:  ${flowVars.temp}\")\n" +
+                                "                .get();\n" +
+                                "    }}");
     }
 }


### PR DESCRIPTION
Only dwl set payload transformations were supported, any other transformation used to error with null pointer exception. This commit fixes that