### PR TITLE
Fixes error when DWL file contains dashes as part of file names

### DIFF
--- a/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/JavaDSLAction2.java
+++ b/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/JavaDSLAction2.java
@@ -156,11 +156,10 @@ public class JavaDSLAction2 extends AbstractAction {
         return new JavaSourceAndType(javaSource, javaSource.getTypes().get(0));
     }
 
-    private JavaSourceAndType createClass(ProjectContext projectContext, String content) {
+    private void createClass(ProjectContext projectContext, String content) {
         JavaSourceSet mainJavaSourceSet = projectContext.getApplicationModules().getTopmostApplicationModules().get(0).getMainJavaSourceSet();
         String packageName = mainJavaSourceSet.getJavaSourceLocation().getPackageName();
-        JavaSource javaSource = mainJavaSourceSet.addJavaSource(projectContext.getProjectRootDirectory(), content, packageName);
-        return new JavaSourceAndType(javaSource, javaSource.getTypes().get(0));
+        mainJavaSourceSet.addJavaSource(projectContext.getProjectRootDirectory(), content, packageName);
     }
 
     // TODO: fina a cohesive name

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLDwlTransformTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLDwlTransformTest.java
@@ -221,4 +221,73 @@ public class MuleToJavaDSLDwlTransformTest extends JavaDSLActionBaseTest {
                                 "                .get();\n" +
                                 "    }}");
     }
+
+    @Test
+    public void shouldNotErrorWhenDWLFileHasDash() {
+        final String dwlExternalFileSpecialChars = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "\n" +
+                "<mule xmlns:dw=\"http://www.mulesoft.org/schema/mule/ee/dw\" xmlns:http=\"http://www.mulesoft.org/schema/mule/http\"\n" +
+                "      xmlns=\"http://www.mulesoft.org/schema/mule/core\" xmlns:doc=\"http://www.mulesoft.org/schema/mule/documentation\"\n" +
+                "      xmlns:spring=\"http://www.springframework.org/schema/beans\"\n" +
+                "      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+                "      xsi:schemaLocation=\"http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd\n" +
+                "http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd\n" +
+                "http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd\n" +
+                "http://www.mulesoft.org/schema/mule/ee/dw http://www.mulesoft.org/schema/mule/ee/dw/current/dw.xsd\">\n" +
+                "    <flow name=\"dwlFlow\">\n" +
+                "        <http:listener config-ref=\"HTTP_Listener_Configuration\" path=\"/dwl\" doc:name=\"HTTP\"/>\n" +
+                "\n" +
+                "        <logger message=\"payload to be sent: #[new String(payload)]\" level=\"INFO\"\n" +
+                "                doc:name=\"Log the message content to be sent\"/>\n" +
+                "\n" +
+                "        <dw:transform-message doc:name=\"action transform via file\">\n" +
+                "            <dw:input-payload mimeType=\"text/plain\">\n" +
+                "                <dw:reader-property name=\"schemaPath\" value=\"schemas/MQOutput.ffd\"/>\n" +
+                "            </dw:input-payload>\n" +
+                "            <dw:set-payload resource=\"classpath:dwl/map-client-risk-rating-response.dwl\"/>\n" +
+                "        </dw:transform-message>\n" +
+                "\n" +
+                "        <logger message=\"payload to be sent: #[new String(payload)]\" level=\"INFO\"\n" +
+                "                doc:name=\"Log the message content to be sent\"/>\n" +
+                "    </flow>\n" +
+                "</mule>";
+        addXMLFileToResource(dwlExternalFileSpecialChars);
+        runAction();
+        assertThat(projectContext.getProjectJavaSources().list()).hasSize(2);
+        assertThat(projectContext.getProjectJavaSources().list().get(0).print())
+                .isEqualTo(
+                        "package com.example.javadsl;\n" +
+                                "import org.springframework.context.annotation.Bean;\n" +
+                                "import org.springframework.context.annotation.Configuration;\n" +
+                                "import org.springframework.integration.dsl.IntegrationFlow;\n" +
+                                "import org.springframework.integration.dsl.IntegrationFlows;\n" +
+                                "import org.springframework.integration.handler.LoggingHandler;\n" +
+                                "import org.springframework.integration.http.dsl.Http;\n" +
+                                "\n" +
+                                "@Configuration\n" +
+                                "public class FlowConfigurations {\n" +
+                                "    @Bean\n" +
+                                "    IntegrationFlow dwlFlow() {\n" +
+                                "        return IntegrationFlows.from(Http.inboundChannelAdapter(\"/dwl\")).handle((p, h) -> p)\n" +
+                                "                .log(LoggingHandler.Level.INFO, \"payload to be sent: #[new String(payload)]\")\n" +
+                                "                .transform(MapclientriskratingresponseTransform::transform)\n" +
+                                "                .log(LoggingHandler.Level.INFO, \"payload to be sent: #[new String(payload)]\")\n" +
+                                "                .get();\n" +
+                                "    }}");
+        assertThat(projectContext.getProjectJavaSources().list().get(1).print())
+                .isEqualTo(
+                        "package com.example.javadsl;\n" +
+                                "\n" +
+                                "public class MapclientriskratingresponseTransform {\n" +
+                                "    /*\n" +
+                                "     * TODO:\n" +
+                                "     *\n" +
+                                "     * Please add necessary transformation for below snippet\n" +
+                                "     * from file dwl/map-client-risk-rating-response.dwl     * */\n" +
+                                "    public static MapclientriskratingresponseTransform transform(Object payload) {\n" +
+                                "\n" +
+                                "        return new MapclientriskratingresponseTransform();\n" +
+                                "    }\n" +
+                                "}");
+    }
 }

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/javadsl/translators/dwl/DwlTransformTranslatorTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/javadsl/translators/dwl/DwlTransformTranslatorTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sbm.mule.actions.javadsl.translators.dwl;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DwlTransformTranslatorTest {
+
+    @ParameterizedTest
+    @CsvSource(value = {
+            "MapClientRiskRatingResponseTransform,classpath:dwl/mapClientRiskRatingResponse.dwl",
+            "MapclientriskratingresponseTransform,classpath:dwl/map-client-risk-rating-response.dwl",
+            "MapclientriskratingresponseTransform,classpath:map client risk rating response.dwl",
+            "MapclientriskratingresponseTransform,classpath:map client risk rating response"
+    },
+            delimiter = ',')
+    void classNameSanitizer(String expected, String input) {
+        assertEquals(
+                expected,
+                DwlTransformTranslator.sanitizeForClassName(input)
+        );
+    }
+}


### PR DESCRIPTION
### Problem

When a dwl transformation referenced a filename with dashes in them, Generated class name which was based on filename also had Dashes in them. Causing an error in SBM. 

This has been fixed.

example:
`<dwltransform-message ...>
    <dw:set[ayload resource="classpath:dwl/get-request-mapping.dwl" />
</dwltransform-message>`

would produce a class file called:
`Get-request-mapping.java`

Now it produces:
`Getrequestmapping.java` 
  