### PR TITLE
130 - Support foreach

### DIFF
--- a/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/javadsl/translators/core/ForeachTranslator.java
+++ b/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/javadsl/translators/core/ForeachTranslator.java
@@ -1,0 +1,49 @@
+package org.springframework.sbm.mule.actions.javadsl.translators.core;
+
+import org.mulesoft.schema.mule.core.ForeachProcessorType;
+import org.springframework.sbm.mule.actions.javadsl.translators.DslSnippet;
+import org.springframework.sbm.mule.actions.javadsl.translators.MuleComponentToSpringIntegrationDslTranslator;
+import org.springframework.sbm.mule.api.toplevel.ForeachTopLevelElement;
+import org.springframework.sbm.mule.api.toplevel.configuration.MuleConfigurations;
+import org.springframework.stereotype.Component;
+
+import javax.xml.namespace.QName;
+import java.util.Map;
+
+import static java.util.Collections.emptySet;
+
+@Component
+public class ForeachTranslator implements MuleComponentToSpringIntegrationDslTranslator<ForeachProcessorType> {
+    @Override
+    public Class<ForeachProcessorType> getSupportedMuleType() {
+        return ForeachProcessorType.class;
+    }
+
+    @Override
+    public DslSnippet translate(int id,
+                                ForeachProcessorType component,
+                                QName name,
+                                MuleConfigurations muleConfigurations,
+                                String flowName,
+                                Map<Class, MuleComponentToSpringIntegrationDslTranslator> translatorsMap
+    ) {
+
+        ForeachTopLevelElement forEachTopLevelTranslations =
+                new ForeachTopLevelElement(
+                        flowName,
+                        component.getMessageProcessorOrOutboundEndpoint(),
+                        muleConfigurations,
+                        translatorsMap
+                );
+        return new DslSnippet(
+                "                //TODO: translate expression " + component.getCollection() + " which must produces an array\n" +
+                "                // to iterate over\n" +
+                "                .split()\n" +
+                "                "+ forEachTopLevelTranslations.renderDslSnippet() +"\n" +
+                "                .aggregate()",
+                emptySet(),
+                emptySet(),
+                emptySet()
+        );
+    }
+}

--- a/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/javadsl/translators/core/ForeachTranslator.java
+++ b/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/javadsl/translators/core/ForeachTranslator.java
@@ -1,6 +1,7 @@
 package org.springframework.sbm.mule.actions.javadsl.translators.core;
 
 import org.mulesoft.schema.mule.core.ForeachProcessorType;
+import org.springframework.sbm.mule.actions.javadsl.translators.Bean;
 import org.springframework.sbm.mule.actions.javadsl.translators.DslSnippet;
 import org.springframework.sbm.mule.actions.javadsl.translators.MuleComponentToSpringIntegrationDslTranslator;
 import org.springframework.sbm.mule.api.toplevel.ForeachTopLevelElement;
@@ -8,7 +9,10 @@ import org.springframework.sbm.mule.api.toplevel.configuration.MuleConfiguration
 import org.springframework.stereotype.Component;
 
 import javax.xml.namespace.QName;
+import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static java.util.Collections.emptySet;
 
@@ -35,15 +39,38 @@ public class ForeachTranslator implements MuleComponentToSpringIntegrationDslTra
                         muleConfigurations,
                         translatorsMap
                 );
+
+        Set<Bean> beans = forEachTopLevelTranslations
+                .getDslSnippets()
+                .stream()
+                .map(DslSnippet::getBeans)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet());
+
+
+        Set<String> requiredImports = forEachTopLevelTranslations
+                .getDslSnippets()
+                .stream()
+                .map(DslSnippet::getRequiredImports)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet());
+
+        Set<String> dependencies = forEachTopLevelTranslations
+                .getDslSnippets()
+                .stream()
+                .map(DslSnippet::getRequiredDependencies)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet());
+
         return new DslSnippet(
                 "                //TODO: translate expression " + component.getCollection() + " which must produces an array\n" +
-                "                // to iterate over\n" +
-                "                .split()\n" +
-                "                "+ forEachTopLevelTranslations.renderDslSnippet() +"\n" +
-                "                .aggregate()",
-                emptySet(),
-                emptySet(),
-                emptySet()
+                        "                // to iterate over\n" +
+                        "                .split()\n" +
+                        "                " + forEachTopLevelTranslations.renderDslSnippet() + "\n" +
+                        "                .aggregate()",
+                requiredImports,
+                dependencies,
+                beans
         );
     }
 }

--- a/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/javadsl/translators/db/SelectTranslator.java
+++ b/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/javadsl/translators/db/SelectTranslator.java
@@ -44,9 +44,11 @@ public class SelectTranslator implements MuleComponentToSpringIntegrationDslTran
 
         String limitString = component.getMaxRows() == null ? "" : " LIMIT " + component.getMaxRows();
 
+        String query = component.getDynamicQuery() == null ? component.getParameterizedQuery()
+                : component.getDynamicQuery();
         return new DslSnippet("// TODO: substitute expression language with appropriate java code \n" +
                 "                .handle((p, h) -> jdbcTemplate.queryForList(\"" +
-                escapeDoubleQuotes(component.getDynamicQuery())
+                escapeDoubleQuotes(query)
                 + limitString + "\"))",
                 Collections.emptySet(),
                 Set.of(

--- a/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/api/toplevel/ApiRouterKitFlowTopLevelElement.java
+++ b/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/api/toplevel/ApiRouterKitFlowTopLevelElement.java
@@ -65,6 +65,7 @@ public class ApiRouterKitFlowTopLevelElement extends AbstractTopLevelElement {
     public Set<String> getRequiredImports() {
         Set<String> requiredImports = super.getRequiredImports();
         requiredImports.add("org.springframework.http.HttpMethod");
+        requiredImports.add("org.springframework.integration.http.dsl.Http");
         return requiredImports;
     }
 

--- a/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/api/toplevel/ChoiceTopLevelElement.java
+++ b/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/api/toplevel/ChoiceTopLevelElement.java
@@ -35,7 +35,6 @@ public class ChoiceTopLevelElement extends AbstractTopLevelElement {
         Set<String> requiredImports = getRequiredImports();
         requiredImports.add("org.springframework.integration.dsl.IntegrationFlow");
         requiredImports.add("org.springframework.integration.dsl.IntegrationFlows");
-        requiredImports.add("org.springframework.integration.amqp.dsl.Amqp");
         getDslSnippets().forEach(ds -> requiredImports.addAll(ds.getRequiredImports()));
         return sb.toString();
     }

--- a/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/api/toplevel/ForeachTopLevelElement.java
+++ b/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/api/toplevel/ForeachTopLevelElement.java
@@ -1,0 +1,31 @@
+package org.springframework.sbm.mule.api.toplevel;
+
+import org.springframework.sbm.mule.actions.javadsl.translators.DslSnippet;
+import org.springframework.sbm.mule.actions.javadsl.translators.MuleComponentToSpringIntegrationDslTranslator;
+import org.springframework.sbm.mule.api.toplevel.configuration.MuleConfigurations;
+
+import javax.xml.bind.JAXBElement;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class ForeachTopLevelElement extends AbstractTopLevelElement{
+
+    protected String composePrefixDslCode() {
+        return "";
+    }
+
+    public String renderDslSnippet() {
+        StringBuilder sb = new StringBuilder();
+        String dsl = getDslSnippets().stream().map(DslSnippet::getRenderedSnippet).collect(Collectors.joining("\n"));
+        sb.append(dsl);
+        return sb.toString();
+    }
+
+    public ForeachTopLevelElement(String flowName,
+                                  List<JAXBElement<?>> elements,
+                                  MuleConfigurations muleConfigurations,
+                                  Map<Class, MuleComponentToSpringIntegrationDslTranslator> translatorsMap) {
+        super(flowName, elements, muleConfigurations, translatorsMap);
+    }
+}

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/JavaDSLActionBaseTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/JavaDSLActionBaseTest.java
@@ -76,7 +76,8 @@ public class JavaDSLActionBaseTest {
                 new DwlTransformTranslator(),
                 new HttpRequestTranslator(),
                 new ChoiceTranslator(),
-                new SelectTranslator()
+                new SelectTranslator(),
+                new ForeachTranslator()
         );
         List<TopLevelElementFactory> topLevelTypeFactories = List.of(
                 new FlowTopLevelElementFactory(translators),

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLDBTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLDBTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MuleToJavaDSLDBTest extends JavaDSLActionBaseTest {
 
     @Test
-    public void translateDbSelectQuery() {
+    public void translateDbSelectDynamicQuery() {
         String muleXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                 "\n" +
                 "<mule xmlns:db=\"http://www.mulesoft.org/schema/mule/db\" xmlns:http=\"http://www.mulesoft.org/schema/mule/http\" xmlns=\"http://www.mulesoft.org/schema/mule/core\" xmlns:doc=\"http://www.mulesoft.org/schema/mule/documentation\"\n" +
@@ -58,6 +58,56 @@ public class MuleToJavaDSLDBTest extends JavaDSLActionBaseTest {
 
         assertThat(listOfImportedArtifacts).contains("spring-integration-jdbc");
         assertThat(listOfImportedArtifacts).contains("spring-boot-starter-jdbc");
+        assertThat(projectContext.getProjectJavaSources().list()).hasSize(1);
+        assertThat(projectContext.getProjectJavaSources().list().get(0).print())
+                .isEqualTo(
+                        "package com.example.javadsl;\n" +
+                                "import org.springframework.context.annotation.Bean;\n" +
+                                "import org.springframework.context.annotation.Configuration;\n" +
+                                "import org.springframework.integration.dsl.IntegrationFlow;\n" +
+                                "import org.springframework.integration.dsl.IntegrationFlows;\n" +
+                                "import org.springframework.integration.handler.LoggingHandler;\n" +
+                                "import org.springframework.integration.http.dsl.Http;\n" +
+                                "\n" +
+                                "@Configuration\n" +
+                                "public class FlowConfigurations {\n" +
+                                "    void dbMysql_config() {\n" +
+                                "        //FIXME: element is not supported for conversion: <db:mysql-config/>\n" +
+                                "    }\n" +
+                                "\n" +
+                                "    @Bean\n" +
+                                "    IntegrationFlow dbFlow(org.springframework.jdbc.core.JdbcTemplate jdbcTemplate) {\n" +
+                                "        return IntegrationFlows.from(Http.inboundChannelAdapter(\"/\")).handle((p, h) -> p)\n" +
+                                "                .log(LoggingHandler.Level.INFO)\n" +
+                                "                // TODO: substitute expression language with appropriate java code \n" +
+                                "                .handle((p, h) -> jdbcTemplate.queryForList(\"SELECT * FROM STUDENTS LIMIT 500\"))\n" +
+                                "                .get();\n" +
+                                "    }}");
+    }
+
+    @Test
+    public void translateDbSelectParameterisedQuery() {
+        String muleXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "\n" +
+                "<mule xmlns:db=\"http://www.mulesoft.org/schema/mule/db\" xmlns:http=\"http://www.mulesoft.org/schema/mule/http\" xmlns=\"http://www.mulesoft.org/schema/mule/core\" xmlns:doc=\"http://www.mulesoft.org/schema/mule/documentation\"\n" +
+                "    xmlns:spring=\"http://www.springframework.org/schema/beans\" \n" +
+                "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+                "    xsi:schemaLocation=\"http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd\n" +
+                "http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd\n" +
+                "http://www.mulesoft.org/schema/mule/db http://www.mulesoft.org/schema/mule/db/current/mule-db.xsd\n" +
+                "http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd\">\n" +
+                "    <db:mysql-config name=\"MySQL_Configuration\" host=\"localhost\" port=\"3036\" user=\"root\" password=\"root\" doc:name=\"MySQL Configuration\"/>\n" +
+                "    <flow name=\"dbFlow\">\n" +
+                "        <http:listener config-ref=\"HTTP_Listener_Configuration\" path=\"/\" doc:name=\"HTTP\"/>\n" +
+                "        <logger level=\"INFO\" doc:name=\"Logger\"/>\n" +
+                "        <db:select config-ref=\"MySQL_Configuration\" doc:name=\"Database\" fetchSize=\"500\" maxRows=\"500\">\n" +
+                "            <db:parameterized-query><![CDATA[SELECT * FROM STUDENTS]]></db:parameterized-query>\n" +
+                "        </db:select>" +
+                "    </flow>\n" +
+                "</mule>\n";
+
+        addXMLFileToResource(muleXml);
+        runAction();
         assertThat(projectContext.getProjectJavaSources().list()).hasSize(1);
         assertThat(projectContext.getProjectJavaSources().list().get(0).print())
                 .isEqualTo(

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLForeachTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLForeachTest.java
@@ -45,7 +45,7 @@ public class MuleToJavaDSLForeachTest extends JavaDSLActionBaseTest {
 
         addXMLFileToResource(xml);
         runAction();
-        assertThat(projectContext.getProjectJavaSources().list().get(0).print()).isEqualTo(
+        assertThat(getGeneratedConfigFile()).isEqualTo(
                 "package com.example.javadsl;\n" +
                         "import org.springframework.context.annotation.Bean;\n" +
                         "import org.springframework.context.annotation.Configuration;\n" +
@@ -107,7 +107,8 @@ public class MuleToJavaDSLForeachTest extends JavaDSLActionBaseTest {
 
         addXMLFileToResource(xml);
         runAction();
-        assertThat(projectContext.getProjectJavaSources().list().get(0).print()).isEqualTo(
+
+        assertThat(getGeneratedConfigFile()).isEqualTo(
                 "package com.example.javadsl;\n" +
                         "import org.springframework.context.annotation.Bean;\n" +
                         "import org.springframework.context.annotation.Configuration;\n" +
@@ -144,5 +145,97 @@ public class MuleToJavaDSLForeachTest extends JavaDSLActionBaseTest {
                         "                .log(LoggingHandler.Level.INFO, \"Done with for looping\")\n" +
                         "                .get();\n" +
                         "    }}");
+    }
+
+    @Test
+    public void forEachWithCallToSubflow() {
+
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "\n" +
+                "<mule xmlns:dw=\"http://www.mulesoft.org/schema/mule/ee/dw\"\n" +
+                "    xmlns:http=\"http://www.mulesoft.org/schema/mule/http\" xmlns:tracking=\"http://www.mulesoft.org/schema/mule/ee/tracking\" xmlns=\"http://www.mulesoft.org/schema/mule/core\" xmlns:doc=\"http://www.mulesoft.org/schema/mule/documentation\"\n" +
+                "    xmlns:spring=\"http://www.springframework.org/schema/beans\" \n" +
+                "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+                "    xsi:schemaLocation=\"\n" +
+                "http://www.mulesoft.org/schema/mule/ee/dw http://www.mulesoft.org/schema/mule/ee/dw/current/dw.xsd http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd\n" +
+                "http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd\n" +
+                "http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd\n" +
+                "http://www.mulesoft.org/schema/mule/ee/tracking http://www.mulesoft.org/schema/mule/ee/tracking/current/mule-tracking-ee.xsd\">\n" +
+                "    <flow name=\"foreach\">\n" +
+                "        <http:listener config-ref=\"HTTP_Listener_Configuration\" path=\"/foreach\" doc:name=\"HTTP\"/>    \n" +
+                "        <foreach collection=\"#[[1, 2, 3, 4]]\">\n" +
+                "            <choice doc:name=\"Choice\">\n" +
+                "            <when expression=\"#[payload == 1]\">\n" +
+                "                <flow-ref name=\"logOneInKannada\"></flow-ref>\n" +
+                "            </when>\n" +
+                "            <when expression=\"#[payload == 2]\">\n" +
+                "                <logger level=\"INFO\" message=\"Eradu\"></logger>\n" +
+                "            </when>\n" +
+                "            <when expression=\"#[payload == 3]\">\n" +
+                "                <logger level=\"INFO\" message=\"Mooru\"></logger>\n" +
+                "            </when>\n" +
+                "            <otherwise>\n" +
+                "                <logger level=\"INFO\" message=\"Moorina mele\"></logger>\n" +
+                "            </otherwise>\n" +
+                "        </choice>\n" +
+                "        </foreach>\n" +
+                "        <logger message=\"Done with for looping\" level=\"INFO\" />\n" +
+                "    </flow>\n" +
+                "    \n" +
+                "    <sub-flow name=\"logOneInKannada\">\n" +
+                "       <logger message=\"Ondu\" level=\"INFO\" doc:name=\"loggerOrdinal\"/>\n" +
+                "   </sub-flow>\n" +
+                "</mule>";
+
+        addXMLFileToResource(xml);
+        runAction();
+
+        assertThat(getGeneratedConfigFile()).isEqualTo(
+                "package com.example.javadsl;\n" +
+                "import org.springframework.context.annotation.Bean;\n" +
+                "import org.springframework.context.annotation.Configuration;\n" +
+                "import org.springframework.integration.dsl.IntegrationFlow;\n" +
+                "import org.springframework.integration.dsl.IntegrationFlows;\n" +
+                "import org.springframework.integration.handler.LoggingHandler;\n" +
+                "import org.springframework.integration.http.dsl.Http;\n" +
+                "\n" +
+                "@Configuration\n" +
+                "public class FlowConfigurations {\n" +
+                "    @Bean\n" +
+                "    IntegrationFlow foreach(org.springframework.integration.dsl.IntegrationFlow logOneInKannada) {\n" +
+                "        return IntegrationFlows.from(Http.inboundChannelAdapter(\"/foreach\")).handle((p, h) -> p)\n" +
+                "                //TODO: translate expression #[[1, 2, 3, 4]] which must produces an array\n" +
+                "                // to iterate over\n" +
+                "                .split()\n" +
+                "                /* TODO: LinkedMultiValueMap might not be apt, substitute with right input type*/\n" +
+                "                .<LinkedMultiValueMap<String, String>, String>route(\n" +
+                "                        p -> p.getFirst(\"dataKey\") /*TODO: use apt condition*/,\n" +
+                "                        m -> m\n" +
+                "                                .subFlowMapping(\"dataValue\" /*TODO: Translate dataValue to #[payload == 1]*/,\n" +
+                "                                        sf -> sf.gateway(logOneInKannada)\n" +
+                "                                )\n" +
+                "                                .subFlowMapping(\"dataValue\" /*TODO: Translate dataValue to #[payload == 2]*/,\n" +
+                "                                        sf -> sf.log(LoggingHandler.Level.INFO, \"Eradu\")\n" +
+                "                                )\n" +
+                "                                .subFlowMapping(\"dataValue\" /*TODO: Translate dataValue to #[payload == 3]*/,\n" +
+                "                                        sf -> sf.log(LoggingHandler.Level.INFO, \"Mooru\")\n" +
+                "                                )\n" +
+                "                                .resolutionRequired(false)\n" +
+                "                                .defaultSubFlowMapping(sf -> sf.log(LoggingHandler.Level.INFO, \"Moorina mele\"))\n" +
+                "                )\n" +
+                "                .aggregate()\n" +
+                "                .log(LoggingHandler.Level.INFO, \"Done with for looping\")\n" +
+                "                .get();\n" +
+                "    }\n" +
+                "\n" +
+                "    @Bean\n" +
+                "    IntegrationFlow logOneInKannada() {\n" +
+                "        return flow -> flow\n" +
+                "                .log(LoggingHandler.Level.INFO, \"Ondu\");\n" +
+                "    }}");
+    }
+
+    private String getGeneratedConfigFile() {
+        return projectContext.getProjectJavaSources().list().get(0).print();
     }
 }

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLForeachTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLForeachTest.java
@@ -58,13 +58,13 @@ public class MuleToJavaDSLForeachTest extends JavaDSLActionBaseTest {
                         "public class FlowConfigurations {\n" +
                         "    @Bean\n" +
                         "    IntegrationFlow foreach() {\n" +
-                        "        return IntegrationFlows.from(Http.inboundGateway(\"/foreachtest\"))\n" +
+                        "        return IntegrationFlows.from(Http.inboundChannelAdapter(\"/foreach\")).handle((p, h) -> p)\n" +
                         "                //TODO: translate expression #[['apple', 'banana', 'orange']] which must produces an array\n" +
                         "                // to iterate over\n" +
                         "                .split()\n" +
-                        "                .log()\n" +
+                        "                .log(LoggingHandler.Level.INFO, \"${payload}\")\n" +
                         "                .aggregate()\n" +
-                        "                .log()\n" +
+                        "                .log(LoggingHandler.Level.INFO, \"Done with for looping\")\n" +
                         "                .get();\n" +
                         "    }}");
     }

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLForeachTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLForeachTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sbm.mule.actions;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MuleToJavaDSLForeachTest extends JavaDSLActionBaseTest {
+
+    @Test
+    public void simpleForEachTest() {
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "\n" +
+                "<mule xmlns:dw=\"http://www.mulesoft.org/schema/mule/ee/dw\"\n" +
+                "    xmlns:http=\"http://www.mulesoft.org/schema/mule/http\" xmlns:tracking=\"http://www.mulesoft.org/schema/mule/ee/tracking\" xmlns=\"http://www.mulesoft.org/schema/mule/core\" xmlns:doc=\"http://www.mulesoft.org/schema/mule/documentation\"\n" +
+                "    xmlns:spring=\"http://www.springframework.org/schema/beans\" \n" +
+                "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+                "    xsi:schemaLocation=\"\n" +
+                "http://www.mulesoft.org/schema/mule/ee/dw http://www.mulesoft.org/schema/mule/ee/dw/current/dw.xsd http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd\n" +
+                "http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd\n" +
+                "http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd\n" +
+                "http://www.mulesoft.org/schema/mule/ee/tracking http://www.mulesoft.org/schema/mule/ee/tracking/current/mule-tracking-ee.xsd\">\n" +
+                "    <flow name=\"foreach\">\n" +
+                "        <http:listener config-ref=\"HTTP_Listener_Configuration\" path=\"/foreach\" doc:name=\"HTTP\"/>    \n" +
+                "        <foreach collection=\"#[['apple', 'banana', 'orange']]\">\n" +
+                "            <logger message=\"#[payload]\" level=\"INFO\" />\n" +
+                "        </foreach>\n" +
+                "        <logger message=\"Done with for looping\" level=\"INFO\" />\n" +
+                "    </flow>\n" +
+                "</mule>";
+
+        addXMLFileToResource(xml);
+        runAction();
+        assertThat(projectContext.getProjectJavaSources().list().get(0).print()).isEqualTo(
+                "package com.example.javadsl;\n" +
+                        "import org.springframework.context.annotation.Bean;\n" +
+                        "import org.springframework.context.annotation.Configuration;\n" +
+                        "import org.springframework.integration.dsl.IntegrationFlow;\n" +
+                        "import org.springframework.integration.dsl.IntegrationFlows;\n" +
+                        "import org.springframework.integration.handler.LoggingHandler;\n" +
+                        "import org.springframework.integration.http.dsl.Http;\n" +
+                        "\n" +
+                        "@Configuration\n" +
+                        "public class FlowConfigurations {\n" +
+                        "    @Bean\n" +
+                        "    IntegrationFlow foreach() {\n" +
+                        "        return IntegrationFlows.from(Http.inboundGateway(\"/foreachtest\"))\n" +
+                        "                //TODO: translate expression #[['apple', 'banana', 'orange']] which must produces an array\n" +
+                        "                // to iterate over\n" +
+                        "                .split()\n" +
+                        "                .log()\n" +
+                        "                .aggregate()\n" +
+                        "                .log()\n" +
+                        "                .get();\n" +
+                        "    }}");
+    }
+}

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLForeachTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLForeachTest.java
@@ -198,6 +198,7 @@ public class MuleToJavaDSLForeachTest extends JavaDSLActionBaseTest {
                 "import org.springframework.integration.dsl.IntegrationFlows;\n" +
                 "import org.springframework.integration.handler.LoggingHandler;\n" +
                 "import org.springframework.integration.http.dsl.Http;\n" +
+                "import org.springframework.util.LinkedMultiValueMap;\n" +
                 "\n" +
                 "@Configuration\n" +
                 "public class FlowConfigurations {\n" +

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLForeachTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLForeachTest.java
@@ -68,4 +68,81 @@ public class MuleToJavaDSLForeachTest extends JavaDSLActionBaseTest {
                         "                .get();\n" +
                         "    }}");
     }
+
+    @Test
+    public void forEachWithChoice() {
+
+        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                "\n" +
+                "<mule xmlns:dw=\"http://www.mulesoft.org/schema/mule/ee/dw\"\n" +
+                "    xmlns:http=\"http://www.mulesoft.org/schema/mule/http\" xmlns:tracking=\"http://www.mulesoft.org/schema/mule/ee/tracking\" xmlns=\"http://www.mulesoft.org/schema/mule/core\" xmlns:doc=\"http://www.mulesoft.org/schema/mule/documentation\"\n" +
+                "    xmlns:spring=\"http://www.springframework.org/schema/beans\" \n" +
+                "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+                "    xsi:schemaLocation=\"\n" +
+                "http://www.mulesoft.org/schema/mule/ee/dw http://www.mulesoft.org/schema/mule/ee/dw/current/dw.xsd http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd\n" +
+                "http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd\n" +
+                "http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd\n" +
+                "http://www.mulesoft.org/schema/mule/ee/tracking http://www.mulesoft.org/schema/mule/ee/tracking/current/mule-tracking-ee.xsd\">\n" +
+                "    <flow name=\"foreach\">\n" +
+                "        <http:listener config-ref=\"HTTP_Listener_Configuration\" path=\"/foreach\" doc:name=\"HTTP\"/>    \n" +
+                "        <foreach collection=\"#[[1, 2, 3, 4]]\">\n" +
+                "            <choice doc:name=\"Choice\">\n" +
+                "            <when expression=\"#[payload == 1]\">\n" +
+                "                <logger level=\"INFO\" message=\"Ondu\"></logger>\n" +
+                "            </when>\n" +
+                "            <when expression=\"#[payload == 2]\">\n" +
+                "                <logger level=\"INFO\" message=\"Eradu\"></logger>\n" +
+                "            </when>\n" +
+                "            <when expression=\"#[payload == 3]\">\n" +
+                "                <logger level=\"INFO\" message=\"Mooru\"></logger>\n" +
+                "            </when>\n" +
+                "            <otherwise>\n" +
+                "                <logger level=\"INFO\" message=\"Moorina mele\"></logger>\n" +
+                "            </otherwise>\n" +
+                "        </choice>\n" +
+                "        </foreach>\n" +
+                "        <logger message=\"Done with for looping\" level=\"INFO\" />\n" +
+                "    </flow>\n" +
+                "</mule>";
+
+        addXMLFileToResource(xml);
+        runAction();
+        assertThat(projectContext.getProjectJavaSources().list().get(0).print()).isEqualTo(
+                "package com.example.javadsl;\n" +
+                        "import org.springframework.context.annotation.Bean;\n" +
+                        "import org.springframework.context.annotation.Configuration;\n" +
+                        "import org.springframework.integration.dsl.IntegrationFlow;\n" +
+                        "import org.springframework.integration.dsl.IntegrationFlows;\n" +
+                        "import org.springframework.integration.handler.LoggingHandler;\n" +
+                        "import org.springframework.integration.http.dsl.Http;\n" +
+                        "\n" +
+                        "@Configuration\n" +
+                        "public class FlowConfigurations {\n" +
+                        "    @Bean\n" +
+                        "    IntegrationFlow foreach() {\n" +
+                        "        return IntegrationFlows.from(Http.inboundChannelAdapter(\"/foreach\")).handle((p, h) -> p)\n" +
+                        "                //TODO: translate expression #[[1, 2, 3, 4]] which must produces an array\n" +
+                        "                // to iterate over\n" +
+                        "                .split()\n" +
+                        "                /* TODO: LinkedMultiValueMap might not be apt, substitute with right input type*/\n" +
+                        "                .<LinkedMultiValueMap<String, String>, String>route(\n" +
+                        "                        p -> p.getFirst(\"dataKey\") /*TODO: use apt condition*/,\n" +
+                        "                        m -> m\n" +
+                        "                                .subFlowMapping(\"dataValue\" /*TODO: Translate dataValue to #[payload == 1]*/,\n" +
+                        "                                        sf -> sf.log(LoggingHandler.Level.INFO, \"Ondu\")\n" +
+                        "                                )\n" +
+                        "                                .subFlowMapping(\"dataValue\" /*TODO: Translate dataValue to #[payload == 2]*/,\n" +
+                        "                                        sf -> sf.log(LoggingHandler.Level.INFO, \"Eradu\")\n" +
+                        "                                )\n" +
+                        "                                .subFlowMapping(\"dataValue\" /*TODO: Translate dataValue to #[payload == 3]*/,\n" +
+                        "                                        sf -> sf.log(LoggingHandler.Level.INFO, \"Mooru\")\n" +
+                        "                                )\n" +
+                        "                                .resolutionRequired(false)\n" +
+                        "                                .defaultSubFlowMapping(sf -> sf.log(LoggingHandler.Level.INFO, \"Moorina mele\"))\n" +
+                        "                )\n" +
+                        "                .aggregate()\n" +
+                        "                .log(LoggingHandler.Level.INFO, \"Done with for looping\")\n" +
+                        "                .get();\n" +
+                        "    }}");
+    }
 }


### PR DESCRIPTION
This commit fixes [issue 130](https://github.com/spring-projects-experimental/spring-boot-migrator/issues/130)

Also it adds support for <db:parameterized-query /> the functionality of which is identical to <db:dynamic-query /> refer to this [PR 119](https://github.com/spring-projects-experimental/spring-boot-migrator/issues/119) for further info on <db:dynamic-query />.

This PR also [fixes](https://github.com/spring-projects-experimental/spring-boot-migrator/pull/136/commits/9d02831dd2cb195d6c5d2f3e8f9c49f5c43ab19f) an issue where API router kit was missing import of symbol `org.springframework.integration.http.dsl.Http`