### PR TITLE
Add support for generating code to send MuleSoft Dataweave Transformations to TriggerMesh

### DIFF
--- a/applications/spring-shell/src/main/resources/application.properties
+++ b/applications/spring-shell/src/main/resources/application.properties
@@ -18,6 +18,7 @@ spring.profiles.active=default, core
 spring.application.name=spring-boot-migrator
 # toggle support for git to sync and auto-commit
 sbm.gitSupportEnabled=true
+sbm.muleTriggerMeshTransformEnabled=true
 logging.level.org=ERROR
 logging.level.org.springframework.sbm.logging.MethodCallTraceInterceptor=DEBUG
 logging.level.org.springframework.sbm.logging.StopWatchTraceInterceptor=DEBUG

--- a/applications/spring-shell/src/main/resources/banner.txt
+++ b/applications/spring-shell/src/main/resources/banner.txt
@@ -38,6 +38,15 @@ Base Package: ${sbm.defaultBasePackage}
 
     Use -Dsbm.defaultBasePackage=com.acme.packagename as VM parameter on startup to set the property.
 
+TriggerMesh transformation support of Dataweave: ${sbm.muleTriggerMeshTransformEnabled}
+
+    - When applying the mule-to-boot recipe, use `sbm.muleTriggerMeshTransformEnabled` to
+      generate the code required to send the Dataweave transformation to TriggerMesh using
+      the TriggerMesh Dataweave transformation service (https://docs.triggermesh.io/guides/dataweavetransformation/).
+    - This will require a TriggerMesh transformation exist on your Kubernetes cluster to function. When running the
+      service, be sure to set the `K_SINK` environment variable to your exposed service URL.
+
+    Use -Dsbm.muleTriggerMeshTransformEnabled=true|false as VM parameter on startup to set property.
 
 Get Started:
 ------------

--- a/applications/spring-shell/src/test/java/org/springframework/sbm/MigrateSimpleMuleAppDataweaveIntegrationTest.java
+++ b/applications/spring-shell/src/test/java/org/springframework/sbm/MigrateSimpleMuleAppDataweaveIntegrationTest.java
@@ -24,8 +24,6 @@ import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@TestMethodOrder(MethodOrderer.MethodName.class)
-//@Disabled("Temporary disabled before CI will be fixed with docker in docker issue: #351")
 class MigrateSimpleMuleAppDataweaveIntegrationTest extends IntegrationTestBaseClass {
     private final RestTemplate restTemplate = new RestTemplate();
     private static RunningNetworkedContainer tmDataweaveContainer;

--- a/applications/spring-shell/src/test/java/org/springframework/sbm/MigrateSimpleMuleAppDataweaveIntegrationTest.java
+++ b/applications/spring-shell/src/test/java/org/springframework/sbm/MigrateSimpleMuleAppDataweaveIntegrationTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sbm;
+
+import org.junit.jupiter.api.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestMethodOrder(MethodOrderer.MethodName.class)
+//@Disabled("Temporary disabled before CI will be fixed with docker in docker issue: #351")
+class MigrateSimpleMuleAppDataweaveIntegrationTest extends IntegrationTestBaseClass {
+    private final RestTemplate restTemplate = new RestTemplate();
+    private static RunningNetworkedContainer tmDataweaveContainer;
+
+    @Override
+    protected String getTestSubDir() {
+
+        return "mule-app/spring-dw-mule";
+
+    }
+
+    @BeforeAll
+    public static void beforeAll() {
+        IntegrationTestBaseClass.beforeAll();
+
+        // Will need to ensure this is set globally for the test
+        System.setProperty("sbm.muleTriggerMeshTransformEnabled", "true");
+
+        // start TriggerMesh Dataweave Translator
+        HashMap<String, String> envMap = new HashMap<>();
+        envMap.put("NAMESPACE", "default");
+        envMap.put("DATAWEAVETRANSFORMATION_ALLOW_SPELL_OVERRIDE", "true");
+
+        tmDataweaveContainer = startDockerContainer(
+                new NetworkedContainer(
+                        "gcr.io/triggermesh/dataweavetransformation-adapter:v1.21.0",
+                        List.of(8080),
+                        "dwhost"),
+                null,
+                envMap);
+        if (!tmDataweaveContainer.getContainer().isRunning()) {
+            throw new RuntimeException("TriggerMesh Dataweave Transformer container could not be started");
+        }
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        if (tmDataweaveContainer != null && tmDataweaveContainer.getContainer() != null) {
+            tmDataweaveContainer.getContainer().stop();
+        }
+    }
+
+    @Test
+    @Tag("integration")
+    public void  t2_dataweaveIntegrationWorks() {
+        intializeTestProject();
+        scanProject();
+        applyRecipe("initialize-spring-boot-migration");
+        applyRecipe("migrate-mule-to-triggermesh-boot");
+
+        executeMavenGoals(getTestDir(), "clean", "package", "spring-boot:build-image");
+
+        int dwPort = tmDataweaveContainer.getContainer().getMappedPort(8080);
+        HashMap<String, String> runtimeEnv = new HashMap<>();
+        runtimeEnv.put("K_SINK", "http://dwhost:8080");
+
+        RunningNetworkedContainer container = startDockerContainer(
+                new NetworkedContainer("hellomuledw-migrated:1.0-SNAPSHOT", List.of(9081), "spring"),
+                tmDataweaveContainer.getNetwork(),
+                runtimeEnv);
+
+        checkSendHttpMessage(container.getContainer().getMappedPort(9081));
+        checkTranslatedInboundGatewayHttpMessage(container.getContainer().getMappedPort(9081));
+    }
+
+    private void checkTranslatedInboundGatewayHttpMessage(int port) {
+        ResponseEntity<String> responseEntity = restTemplate.getForEntity("http://localhost:" + port + "/dwtest", String.class);
+
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(responseEntity.getBody()).isEqualTo("\n{\n  \"greeting\": \"hello from SBM\"\n}");
+    }
+
+    private void checkSendHttpMessage(int port) {
+        ResponseEntity<String> responseEntity = restTemplate.getForEntity("http://localhost:" + port + "/test", String.class);
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+}

--- a/applications/spring-shell/src/test/resources/testcode/mule-app/spring-dw-mule/.gitignore
+++ b/applications/spring-shell/src/test/resources/testcode/mule-app/spring-dw-mule/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/applications/spring-shell/src/test/resources/testcode/mule-app/spring-dw-mule/pom.xml
+++ b/applications/spring-shell/src/test/resources/testcode/mule-app/spring-dw-mule/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2021 - 2022 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>hellomuledw-migrated</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.8.2</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/applications/spring-shell/src/test/resources/testcode/mule-app/spring-dw-mule/src/main/java/com/example/javadsl/Foo.java
+++ b/applications/spring-shell/src/test/resources/testcode/mule-app/spring-dw-mule/src/main/java/com/example/javadsl/Foo.java
@@ -1,0 +1,7 @@
+package com.example.javadsl;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class Foo {
+}

--- a/applications/spring-shell/src/test/resources/testcode/mule-app/spring-dw-mule/src/main/resources/apikit-dw-mule.xml
+++ b/applications/spring-shell/src/test/resources/testcode/mule-app/spring-dw-mule/src/main/resources/apikit-dw-mule.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2021 - 2022 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<mule xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:dw="http://www.mulesoft.org/schema/mule/ee/dw"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd http://www.mulesoft.org/schema/mule/ee/dw">
+    <flow name="get:/dwtest:dwtest-config">
+        <dw:transform-message doc:name="Transform Message">
+            <dw:set-payload><![CDATA[%dw 2.0
+output application/json
+---
+greeting: "hello from SBM"
+]]>
+            </dw:set-payload>
+        </dw:transform-message>
+    </flow>
+</mule>

--- a/applications/spring-shell/src/test/resources/testcode/mule-app/spring-dw-mule/src/main/resources/http-mule.xml
+++ b/applications/spring-shell/src/test/resources/testcode/mule-app/spring-dw-mule/src/main/resources/http-mule.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2021 - 2022 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<mule xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
+    <http:listener-config name="HTTP_Listener_Configuration" host="0.0.0.0" port="9081" doc:name="HTTP Listener Configuration"/>
+    <flow name="http-flow">
+        <http:listener doc:name="Listener" doc:id="9f602d5c-5386-4fc9-ac8f-024d754c17e5" config-ref="HTTP_Listener_Configuration" path="/test"/>
+        <logger level="INFO" doc:name="Logger" doc:id="4585ec7f-2d4a-4d86-af24-b678d4a99227" />
+    </flow>
+</mule>

--- a/components/sbm-core/src/main/java/org/springframework/sbm/project/resource/SbmApplicationProperties.java
+++ b/components/sbm-core/src/main/java/org/springframework/sbm/project/resource/SbmApplicationProperties.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 @ConfigurationProperties(prefix = "sbm")
 public class SbmApplicationProperties {
     private boolean gitSupportEnabled;
+    private boolean muleTriggerMeshTransformEnabled;
     private String defaultBasePackage;
     private boolean writeInMavenLocal;
     private boolean  javaParserLoggingCompilationWarningsAndErrors;

--- a/components/sbm-core/src/main/resources/application-core.properties
+++ b/components/sbm-core/src/main/resources/application-core.properties
@@ -18,6 +18,8 @@
 
 # toggle support for git to sync and auto-commit
 sbm.gitSupportEnabled=true
+# toggle support to use TriggerMesh for dataweave transformations
+sbm.muleTriggerMeshTransformEnabled=false
 # default base package when adding classes and no base package can be calculated
 sbm.defaultBasePackage=org.springframework.sbm
 # default groupId when creating a new build file

--- a/components/sbm-core/src/test/java/org/springframework/sbm/project/parser/ProjectContextInitializerTest.java
+++ b/components/sbm-core/src/test/java/org/springframework/sbm/project/parser/ProjectContextInitializerTest.java
@@ -87,7 +87,7 @@ import static org.springframework.sbm.project.parser.ResourceVerifierTestHelper.
         JavaRefactoringFactoryImpl.class,
         ProjectResourceWrapperRegistry.class,
         RewriteSourceFileWrapper.class
-}, properties = {"sbm.gitSupportEnabled=false"})
+}, properties = {"sbm.gitSupportEnabled=false", "sbm.muleTriggerMeshTransformEnabled=false"})
 @Disabled
 class ProjectContextInitializerTest {
 

--- a/components/sbm-core/src/test/java/org/springframework/sbm/project/parser/ProjectContextInitializerTest.java
+++ b/components/sbm-core/src/test/java/org/springframework/sbm/project/parser/ProjectContextInitializerTest.java
@@ -87,7 +87,7 @@ import static org.springframework.sbm.project.parser.ResourceVerifierTestHelper.
         JavaRefactoringFactoryImpl.class,
         ProjectResourceWrapperRegistry.class,
         RewriteSourceFileWrapper.class
-}, properties = {"sbm.gitSupportEnabled=false", "sbm.muleTriggerMeshTransformEnabled=false"})
+}, properties = {"sbm.gitSupportEnabled=false"})
 @Disabled
 class ProjectContextInitializerTest {
 

--- a/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/MigrateMuleToBoot.java
+++ b/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/MigrateMuleToBoot.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.sbm.mule;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -30,23 +31,34 @@ import org.springframework.sbm.java.migration.conditions.HasNoTypeAnnotation;
 import org.springframework.sbm.java.migration.conditions.HasTypeAnnotation;
 import org.springframework.sbm.mule.actions.JavaDSLAction2;
 import org.springframework.sbm.mule.conditions.MuleConfigFileExist;
+import org.springframework.sbm.project.resource.SbmApplicationProperties;
 
 import java.util.List;
 
+@RequiredArgsConstructor
 @Configuration
 public class MigrateMuleToBoot {
+    private final SbmApplicationProperties sbmProperties;
 
     @Autowired
     private JavaDSLAction2 javaDSLAction2;
 
-
     @Bean
     public Recipe muleRecipe() {
+        String name = "migrate-mule-to-boot";
+        String description = "Migrate Mulesoft 3.9 to Spring Boot.";
+
+        // Flag to enable TriggerMesh ransformation mode
+        if (sbmProperties.isMuleTriggerMeshTransformEnabled()) {
+            name = "migrate-mule-to-triggermesh-boot";
+            description = "Migrate Mulesoft 3.9 to Spring Boot using TriggerMesh.";
+            javaDSLAction2.setMuleTriggerMeshTransformEnabled(true);
+        }
+
         return Recipe.builder()
-                .name("migrate-mule-to-boot")
-                .description("Migrate Mulesoft 3.9 to Spring Boot")
+                .name(name)
+                .description(description)
                 .order(60)
-                .description("Migrate Mulesoft to Spring Boot")
                 .condition(new MuleConfigFileExist())
                 .actions(List.of(
                         /*

--- a/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/JavaDSLAction2.java
+++ b/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/JavaDSLAction2.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.sbm.mule.actions;
 
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -56,6 +57,7 @@ public class JavaDSLAction2 extends AbstractAction {
     private final MuleMigrationContextFactory muleMigrationContextFactory;
     private final Map<Class<?>, TopLevelElementFactory> topLevelTypeMap;
 
+    @Setter
     private boolean muleTriggerMeshTransformEnabled;
 
     @Autowired
@@ -236,10 +238,6 @@ public class JavaDSLAction2 extends AbstractAction {
                 .filter(SpringBootApplicationProperties::isDefaultProperties)
                 .findFirst()
                 .get();
-    }
-
-    public void setMuleTriggerMeshTransformEnabled(boolean mode) {
-        this.muleTriggerMeshTransformEnabled = mode;
     }
 
     private String createTmDwPayloadClass(ProjectContext projectContext) {

--- a/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/javadsl/translators/dwl/DwlTransformTranslator.java
+++ b/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/javadsl/translators/dwl/DwlTransformTranslator.java
@@ -63,7 +63,7 @@ public class DwlTransformTranslator implements MuleComponentToSpringIntegrationD
             "}\n";
 
     private static final String triggermeshPayloadHandlerContent = "" +
-            ".<LinkedMultiValueMap<String, String>>handle((p, h) -> {\n" +
+            ".handle((p, h) -> {\n" +
             "                    TmDwPayload dwPayload = new TmDwPayload();\n" +
             "                    dwPayload.setId(h.getId().toString());\n" +
             "                    dwPayload.setSourceType(h.get(\"contentType\").toString());\n" +

--- a/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/javadsl/translators/dwl/DwlTransformTranslator.java
+++ b/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/javadsl/translators/dwl/DwlTransformTranslator.java
@@ -24,15 +24,16 @@ import org.springframework.sbm.mule.api.toplevel.configuration.MuleConfiguration
 import org.springframework.stereotype.Component;
 
 import javax.xml.namespace.QName;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
 @Component
 public class DwlTransformTranslator implements MuleComponentToSpringIntegrationDslTranslator<TransformMessageType> {
-    public static final String STATEMENT_CONTENT = ".transform($CLASSNAME::transform)";
-    private static final String externalClassContentPrefixTemplate = "package com.example.javadsl;\n" +
-            "\n" +
+    public static final String TRANSFORM_STATEMENT_CONTENT = ".transform($CLASSNAME::transform)";
+    public static final String externalPackageName = "package com.example.javadsl;\n\n";
+
+    /* Define the stubs for adding the transformation as a comment to be addressed */
+    private static final String externalClassContentPrefixTemplate = externalPackageName +
             "public class $CLASSNAME {\n" +
             "    /*\n" +
             "     * TODO:\n" +
@@ -45,6 +46,87 @@ public class DwlTransformTranslator implements MuleComponentToSpringIntegrationD
             "        return new $CLASSNAME();\n" +
             "    }\n" +
             "}";
+
+    /* Define the TriggerMesh specific stubs when enabled. This will capture the transformation, and send it along
+     * with the payload to the TriggerMesh Dataweave Transformation Service.
+     */
+    // Independent class to capture parts of the message header from the spring integration to inject into the transformation
+    private static final String triggermeshDWPayload = "" +
+            "package com.example.javadsl;\n\n" +
+            "import lombok.Data;\n\n" +
+            "@Data\n" +
+            "public class TmDwPayload {\n" +
+            "\tprivate String id;\n" +
+            "\tprivate String source;\n" +
+            "\tprivate String sourceType;\n" +
+            "\tprivate String payload;\n" +
+            "}\n";
+
+    private static final String triggermeshPayloadHandlerContent = "" +
+            ".<LinkedMultiValueMap<String, String>>handle((p, h) -> {\n" +
+            "                    TmDwPayload dwPayload = new TmDwPayload();\n" +
+            "                    dwPayload.setId(h.getId().toString());\n" +
+            "                    dwPayload.setSourceType(h.get(\"contentType\").toString());\n" +
+            "                    dwPayload.setSource(h.get(\"http_requestUrl\").toString());\n" +
+            "                    dwPayload.setPayload(p.toString());\n" +
+            "                    return dwPayload;\n" +
+            "                })";
+    private static final String triggermeshImportsTemplate = "import com.fasterxml.jackson.databind.ObjectMapper;\n\n" +
+            "import java.net.URI;\n" +
+            "import java.net.http.HttpClient;\n" +
+            "import java.net.http.HttpRequest;\n" +
+            "import java.net.http.HttpResponse;\n";
+
+    private static final String triggermeshDWTransformationClass = "" +
+            "\tpublic static class DataWeavePayload {\n" +
+            "\t    public String input_data;\n" +
+            "\t    public String spell;\n" +
+            "\t    public String input_content_type;\n" +
+            "\t    public String output_content_type;\n" +
+            "\t};";
+
+    private static final String triggermeshClassTemplate = externalPackageName + triggermeshImportsTemplate +
+            "\npublic class $CLASSNAME {\n" +
+            triggermeshDWTransformationClass + "\n\n" +
+            "\tpublic static String transform(TmDwPayload payload) {\n" +
+            "\t\tString uuid = payload.getId();\n" +
+            "\t\tString url = System.getenv(\"K_SINK\");\n" + // NOTE: K_SINK is the URL for the target transformation service
+            "\t\tHttpClient client = HttpClient.newHttpClient();\n" +
+            "\t\tHttpRequest.Builder requestBuilder;\n" +
+            "\t\tDataWeavePayload dwPayload = new DataWeavePayload();\n" +
+            "\t\tif (payload.getSourceType().contains(\";\")) {\n" +
+            "\t\t\tdwPayload.input_content_type = payload.getSourceType().split(\";\")[0];\n" +
+            "\t\t} else {\n" +
+            "\t\t\tdwPayload.input_content_type = payload.getSourceType();\n" +
+            "\t\t}\n" +
+            "\t\tdwPayload.output_content_type = \"$OUTPUT_CONTENT_TYPE\";\n" +
+            "\t\t//TODO: Verify the spell conforms to Dataweave 2.x: https://docs.mulesoft.com/mule-runtime/4.4/migration-dataweave\n" +
+            "\t\tdwPayload.spell = \"$DWSPELL\";\n" +
+            "\t\tdwPayload.input_data = payload.getPayload();\n" +
+            "\t\tString body;\n\n" +
+            "\t\ttry {\n" +
+            "\t\t\trequestBuilder = HttpRequest.newBuilder(new URI(url));\n" +
+            "\t\t\tObjectMapper om = new ObjectMapper();\n" +
+            "\t\t\tbody = om.writeValueAsString(dwPayload);\n" +
+            "\t\t} catch (Exception e) {\n" +
+            "\t\t\tSystem.out.println(\"Error sending request: \" + e.toString());\n" +
+            "\t\t\treturn null;\n" +
+            "\t\t}\n\n" +
+            "\t\trequestBuilder.setHeader(\"content-type\", \"application/json\");\n" +
+            "\t\trequestBuilder.setHeader(\"ce-specversion\", \"1.0\");\n" +
+            "\t\trequestBuilder.setHeader(\"ce-source\", payload.getSource());\n" +
+            "\t\trequestBuilder.setHeader(\"ce-type\", \"io.triggermesh.dataweave.transform\");\n" +
+            "\t\trequestBuilder.setHeader(\"ce-id\", payload.getId());\n\n" +
+            "\t\tHttpRequest request = requestBuilder.POST(HttpRequest.BodyPublishers.ofString(body)).build();\n\n" +
+            "\t\ttry {\n" +
+            "\t\t\tHttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());\n" +
+            "\t\t\t // TODO: verify the response status and body\n" +
+            "\t\t\treturn response.body();\n" +
+            "\t\t} catch (Exception e) {\n" +
+            "\t\t\tSystem.out.println(\"Error sending event: \" + e.toString());\n" +
+            "\t\t\treturn null;\n" +
+            "\t\t}\n" +
+            "\t}\n";
 
     @Override
     public Class<TransformMessageType> getSupportedMuleType() {
@@ -66,7 +148,8 @@ public class DwlTransformTranslator implements MuleComponentToSpringIntegrationD
                 return formExternalFileBasedDSLSnippet(component);
             }
 
-            return formEmbeddedDWLBasedDSLSnippet(component, Helper.sanitizeForBeanMethodName(flowName), id);
+            //return formEmbeddedDWLBasedDSLSnippet(component, Helper.sanitizeForBeanMethodName(flowName), id);
+            return formTriggerMeshDWLBasedDSLSnippet(component, Helper.sanitizeForBeanMethodName(flowName), id);
         }
 
         return noSupportDslSnippet();
@@ -90,9 +173,50 @@ public class DwlTransformTranslator implements MuleComponentToSpringIntegrationD
                         replaceClassName(externalClassContentSuffixTemplate, className);
 
         return DslSnippet.builder()
-                .renderedSnippet(replaceClassName(STATEMENT_CONTENT, className))
+                .renderedSnippet(replaceClassName(TRANSFORM_STATEMENT_CONTENT, className))
                 .externalClassContent(externalClassContent)
                 .build();
+    }
+
+    private DslSnippet formTriggerMeshDWLBasedDSLSnippet(TransformMessageType component, String flowName, int id) {
+        String className = capitalizeFirstLetter(flowName) + "TransformTM_" + id;
+        String dwlSpell = component.getSetPayload().getContent().toString();
+
+        // Locate the output content type based on the spell. If it isn't present, default to
+        // application/json
+        String outputContentType = getSpellOutputType(dwlSpell);
+        String tmTransformationContent = triggermeshClassTemplate
+                .replace("$CLASSNAME", className)
+                .replace("$OUTPUT_CONTENT_TYPE", outputContentType)
+                .replace("$DWSPELL", sanitizeSpell(dwlSpell));
+
+        // Build the dw payload
+        return DslSnippet.builder()
+                .externalClassContent(triggermeshDWPayload)
+                .renderedSnippet(triggermeshPayloadHandlerContent + "\n" + replaceClassName(TRANSFORM_STATEMENT_CONTENT, className))
+                .externalClassContent(tmTransformationContent)
+                .requiredImports(Set.of("java.net.URI", "java.net.http.HttpClient", "java.net.http.HttpRequest", "java.net.http.HttpResponse", "com.fasterxml.jackson.databind.ObjectMapper"))
+                .build();
+    }
+
+    private String getSpellOutputType(String spell) {
+        String spellOutputType = "application/json";
+
+        String []spellElements = spell.split(" ");
+        for (int i = 0; i < spellElements.length; i++) {
+            if (spellElements[i].equals("%output")) {
+                spellOutputType = spellElements[i+1].trim();
+                break;
+            } else if (spellElements[i].equals("---")) {
+                break;
+            }
+        }
+
+        if (spellOutputType.contains(";")) {
+            spellOutputType = spellOutputType.split(";")[0];
+        }
+
+        return spellOutputType;
     }
 
     private DslSnippet formExternalFileBasedDSLSnippet(TransformMessageType component) {
@@ -104,7 +228,7 @@ public class DwlTransformTranslator implements MuleComponentToSpringIntegrationD
                         + resource.replace("classpath:", "")
                         + replaceClassName(externalClassContentSuffixTemplate, className);
         return DslSnippet.builder()
-                .renderedSnippet(replaceClassName(STATEMENT_CONTENT, className))
+                .renderedSnippet(replaceClassName(TRANSFORM_STATEMENT_CONTENT, className))
                 .externalClassContent(content)
                 .build();
     }
@@ -113,6 +237,18 @@ public class DwlTransformTranslator implements MuleComponentToSpringIntegrationD
         String sanitizedClassName = getFileName(classNameCandidate)
                 .replaceAll("[^a-zA-Z0-9]", "");
         return (capitalizeFirstLetter(sanitizedClassName) + "Transform");
+    }
+
+    // Remove the leading/trailing spaces, [], ensure the double quote marks are escaped, and swap out the newlines
+    private static String sanitizeSpell(String spell) {
+        String s = spell.trim();
+        if (s.charAt(0) == '[' && s.charAt(s.length() -1) == ']') {
+            s = s.substring(1);
+            s = s.substring(0, s.length() - 1);
+        }
+        s = s.replace("\"", "\\\"");
+        s = s.replace("\n", "\\n");
+        return s;
     }
 
     private boolean isComponentReferencingAnExternalFile(TransformMessageType component) {

--- a/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/javadsl/translators/dwl/DwlTransformTranslator.java
+++ b/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/javadsl/translators/dwl/DwlTransformTranslator.java
@@ -142,14 +142,19 @@ public class DwlTransformTranslator implements MuleComponentToSpringIntegrationD
             String flowName,
             Map<Class, MuleComponentToSpringIntegrationDslTranslator> translatorsMap
     ) {
+        // Ugly hack to work around an inability to inject a sbm property into the mulesoft parser.
+        String isTmTransformationEnabled = System.getProperty("sbm.muleTriggerMeshTransformEnabled");
 
         if (component.getSetPayload() != null) {
             if (isComponentReferencingAnExternalFile(component)) {
                 return formExternalFileBasedDSLSnippet(component);
             }
 
-            //return formEmbeddedDWLBasedDSLSnippet(component, Helper.sanitizeForBeanMethodName(flowName), id);
-            return formTriggerMeshDWLBasedDSLSnippet(component, Helper.sanitizeForBeanMethodName(flowName), id);
+            if (isTmTransformationEnabled != null && isTmTransformationEnabled.equals("true")) {
+                return formTriggerMeshDWLBasedDSLSnippet(component, Helper.sanitizeForBeanMethodName(flowName), id);
+            } else {
+                return formEmbeddedDWLBasedDSLSnippet(component, Helper.sanitizeForBeanMethodName(flowName), id);
+            }
         }
 
         return noSupportDslSnippet();

--- a/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/javadsl/translators/dwl/DwlTransformTranslator.java
+++ b/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/javadsl/translators/dwl/DwlTransformTranslator.java
@@ -16,11 +16,14 @@
 
 package org.springframework.sbm.mule.actions.javadsl.translators.dwl;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import freemarker.cache.FileTemplateLoader;
 import freemarker.template.Configuration;
 import freemarker.template.Version;
 import freemarker.template.Template;
+import lombok.Setter;
 import org.mulesoft.schema.mule.ee.dw.TransformMessageType;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.sbm.java.util.Helper;
 import org.springframework.sbm.mule.actions.javadsl.translators.DslSnippet;
 import org.springframework.sbm.mule.actions.javadsl.translators.MuleComponentToSpringIntegrationDslTranslator;
@@ -37,6 +40,11 @@ import java.util.Map;
 public class DwlTransformTranslator implements MuleComponentToSpringIntegrationDslTranslator<TransformMessageType> {
     public static final String TRANSFORM_STATEMENT_CONTENT = ".transform($CLASSNAME::transform)";
     public static final String externalPackageName = "com.example.javadsl";
+
+    @Autowired
+    @Setter
+    @JsonIgnore
+    private Configuration templateConfiguration;
 
     /* Define the stubs for adding the transformation as a comment to be addressed */
     private static final String externalClassContentPrefixTemplate = "package " + externalPackageName + ";\n\n" +
@@ -137,8 +145,12 @@ public class DwlTransformTranslator implements MuleComponentToSpringIntegrationD
 
         StringWriter sw  = new StringWriter();
         try {
-            Configuration templateConfiguration = new Configuration(new Version("2.3.0"));
-            templateConfiguration.setTemplateLoader(new FileTemplateLoader(new File("./src/main/resources/templates")));
+            // In cases where the template library is not initialized (unit testing)
+            if (templateConfiguration == null) {
+                templateConfiguration = new Configuration(new Version("2.3.0"));
+                templateConfiguration.setTemplateLoader(new FileTemplateLoader(new File("./src/main/resources/templates")));
+            }
+
             Template template = templateConfiguration.getTemplate("triggermesh-dw-transformation-template.ftl");
             template.process(templateParams, sw);
         } catch (Exception e) {

--- a/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/javadsl/translators/dwl/DwlTransformTranslator.java
+++ b/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/javadsl/translators/dwl/DwlTransformTranslator.java
@@ -68,8 +68,10 @@ public class DwlTransformTranslator implements MuleComponentToSpringIntegrationD
     private static final String triggermeshPayloadHandlerContent = "" +
             ".handle((p, h) -> {\n" +
             "                    TmDwPayload dwPayload = new TmDwPayload();\n" +
+            "                    String contentType = \"application/json\";\n" +
+            "                    if (h.get(\"contentType\") != null) { contentType = h.get(\"contentType\").toString(); }\n" +
             "                    dwPayload.setId(h.getId().toString());\n" +
-            "                    dwPayload.setSourceType(h.get(\"contentType\").toString());\n" +
+            "                    dwPayload.setSourceType(contentType);\n" +
             "                    dwPayload.setSource(h.get(\"http_requestUrl\").toString());\n" +
             "                    dwPayload.setPayload(p.toString());\n" +
             "                    return dwPayload;\n" +

--- a/components/sbm-recipes-mule-to-boot/src/main/resources/templates/triggermesh-dw-transformation-template.ftl
+++ b/components/sbm-recipes-mule-to-boot/src/main/resources/templates/triggermesh-dw-transformation-template.ftl
@@ -1,8 +1,8 @@
 <#if packageName?has_content>
-    package ${packageName};
+package ${packageName};
 
 <#else>
-    package com.example.javadsl;
+package com.example.javadsl;
 
 </#if>
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -14,11 +14,11 @@ import java.net.http.HttpResponse;
 
 public class ${className} {
     public static class DataWeavePayload {
-    public String input_data;
-    public String spell;
-    public String input_content_type;
-    public String output_content_type;
-};
+        public String input_data;
+        public String spell;
+        public String input_content_type;
+        public String output_content_type;
+    };
 
     public static String transform(TmDwPayload payload) {
         String uuid = payload.getId();

--- a/components/sbm-recipes-mule-to-boot/src/main/resources/templates/triggermesh-dw-transformation-template.ftl
+++ b/components/sbm-recipes-mule-to-boot/src/main/resources/templates/triggermesh-dw-transformation-template.ftl
@@ -1,0 +1,68 @@
+<#if packageName?has_content>
+    package ${packageName};
+
+<#else>
+    package com.example.javadsl;
+
+</#if>
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+public class ${className} {
+    public static class DataWeavePayload {
+    public String input_data;
+    public String spell;
+    public String input_content_type;
+    public String output_content_type;
+};
+
+    public static String transform(TmDwPayload payload) {
+        String uuid = payload.getId();
+        String url = System.getenv("K_SINK");
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest.Builder requestBuilder;
+        DataWeavePayload dwPayload = new DataWeavePayload();
+
+        if (payload.getSourceType().contains(";")) {
+            dwPayload.input_content_type = payload.getSourceType().split(";")[0];
+        } else {
+            dwPayload.input_content_type = payload.getSourceType();
+        }
+        dwPayload.output_content_type = "${outputContentType}";
+
+        //TODO: Verify the spell conforms to Dataweave 2.x: https://docs.mulesoft.com/mule-runtime/4.4/migration-dataweave
+        dwPayload.spell = "${dwSpell}";
+        dwPayload.input_data = payload.getPayload();
+        String body;
+
+        try {
+            requestBuilder = HttpRequest.newBuilder(new URI(url));
+            ObjectMapper om = new ObjectMapper();
+            body = om.writeValueAsString(dwPayload);
+        } catch (Exception e) {
+            System.out.println("Error sending request: " + e.toString());
+            return null;
+        }
+
+        requestBuilder.setHeader("content-type", "application/json");
+        requestBuilder.setHeader("ce-specversion", "1.0");
+        requestBuilder.setHeader("ce-source", payload.getSource());
+        requestBuilder.setHeader("ce-type", "io.triggermesh.dataweave.transform");
+        requestBuilder.setHeader("ce-id", payload.getId());
+
+        HttpRequest request = requestBuilder.POST(HttpRequest.BodyPublishers.ofString(body)).build();
+
+        try {
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            // TODO: verify the response status and body
+            return response.body();
+        } catch (Exception e) {
+            System.out.println("Error sending event: " + e.toString());
+            return null;
+        }
+    }
+}

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLDwlTransformTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLDwlTransformTest.java
@@ -130,8 +130,12 @@ public class MuleToJavaDSLDwlTransformTest extends JavaDSLActionBaseTest {
                                 "                .log(LoggingHandler.Level.INFO, \"payload to be sent: #[new String(payload)]\")\n" +
                                 "                .handle((p, h) -> {\n" +
                                 "                    TmDwPayload dwPayload = new TmDwPayload();\n" +
+                                "                    String contentType = \"application/json\";\n" +
+                                "                    if (h.get(\"contentType\") != null) {\n" +
+                                "                        contentType = h.get(\"contentType\").toString();\n" +
+                                "                    }\n" +
                                 "                    dwPayload.setId(h.getId().toString());\n" +
-                                "                    dwPayload.setSourceType(h.get(\"contentType\").toString());\n" +
+                                "                    dwPayload.setSourceType(contentType);\n" +
                                 "                    dwPayload.setSource(h.get(\"http_requestUrl\").toString());\n" +
                                 "                    dwPayload.setPayload(p.toString());\n" +
                                 "                    return dwPayload;\n" +

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLDwlTransformTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLDwlTransformTest.java
@@ -62,47 +62,48 @@ public class MuleToJavaDSLDwlTransformTest extends JavaDSLActionBaseTest {
         assertThat(projectContext.getProjectJavaSources().list()).hasSize(2);
         assertThat(getGeneratedJavaFile())
                 .isEqualTo(
-                        "package com.example.javadsl;\n" +
-                                "import org.springframework.context.annotation.Bean;\n" +
-                                "import org.springframework.context.annotation.Configuration;\n" +
-                                "import org.springframework.integration.dsl.IntegrationFlow;\n" +
-                                "import org.springframework.integration.dsl.IntegrationFlows;\n" +
-                                "import org.springframework.integration.handler.LoggingHandler;\n" +
-                                "import org.springframework.integration.http.dsl.Http;\n" +
-                                "\n" +
-                                "@Configuration\n" +
-                                "public class FlowConfigurations {\n" +
-                                "    @Bean\n" +
-                                "    IntegrationFlow dwlFlow() {\n" +
-                                "        return IntegrationFlows.from(Http.inboundChannelAdapter(\"/dwl\")).handle((p, h) -> p)\n" +
-                                "                .log(LoggingHandler.Level.INFO, \"payload to be sent: #[new String(payload)]\")\n" +
-                                "                .transform(DwlFlowTransform_2::transform)\n" +
-                                "                .log(LoggingHandler.Level.INFO, \"payload to be sent: #[new String(payload)]\")\n" +
-                                "                .get();\n" +
-                                "    }\n" +
-                                "}");
+                        """
+                                package com.example.javadsl;
+                                import org.springframework.context.annotation.Bean;
+                                import org.springframework.context.annotation.Configuration;
+                                import org.springframework.integration.dsl.IntegrationFlow;
+                                import org.springframework.integration.dsl.IntegrationFlows;
+                                import org.springframework.integration.handler.LoggingHandler;
+                                import org.springframework.integration.http.dsl.Http;
+                                                                
+                                @Configuration
+                                public class FlowConfigurations {
+                                    @Bean
+                                    IntegrationFlow dwlFlow() {
+                                        return IntegrationFlows.from(Http.inboundChannelAdapter("/dwl")).handle((p, h) -> p)
+                                                .log(LoggingHandler.Level.INFO, "payload to be sent: #[new String(payload)]")
+                                                .transform(DwlFlowTransform_2::transform)
+                                                .log(LoggingHandler.Level.INFO, "payload to be sent: #[new String(payload)]")
+                                                .get();
+                                    }
+                                }""");
         assertThat(projectContext.getProjectJavaSources().list().get(1).print())
-                .isEqualTo(
-                        "package com.example.javadsl;\n" +
-                                "\n" +
-                                "public class DwlFlowTransform_2 {\n" +
-                                "    /*\n" +
-                                "     * TODO:\n" +
-                                "     *\n" +
-                                "     * Please add necessary transformation for below snippet\n" +
-                                "     * [%dw 1.0\n" +
-                                "     * %output application/json\n" +
-                                "     * ---\n" +
-                                "     * {\n" +
-                                "     *     action_Code: 10,\n" +
-                                "     *     returnCode:  20\n" +
-                                "     * }]\n" +
-                                "     * */\n" +
-                                "    public static DwlFlowTransform_2 transform(Object payload) {\n" +
-                                "\n" +
-                                "        return new DwlFlowTransform_2();\n" +
-                                "    }\n" +
-                                "}");
+                .isEqualTo("""
+                                   package com.example.javadsl;
+                                                                      
+                                   public class DwlFlowTransform_2 {
+                                       /*
+                                        * TODO:
+                                        *
+                                        * Please add necessary transformation for below snippet
+                                        * [%dw 1.0
+                                        * %output application/json
+                                        * ---
+                                        * {
+                                        *     action_Code: 10,
+                                        *     returnCode:  20
+                                        * }]
+                                        * */
+                                       public static DwlFlowTransform_2 transform(Object payload) {
+                                                                      
+                                           return new DwlFlowTransform_2();
+                                       }
+                                   }""");
     }
 
     @Test
@@ -113,402 +114,414 @@ public class MuleToJavaDSLDwlTransformTest extends JavaDSLActionBaseTest {
 
         assertThat(projectContext.getProjectJavaSources().list()).hasSize(3);
         assertThat(getGeneratedJavaFile())
-                .isEqualTo(
-                        "package com.example.javadsl;\n" +
-                                "import org.springframework.context.annotation.Bean;\n" +
-                                "import org.springframework.context.annotation.Configuration;\n" +
-                                "import org.springframework.integration.dsl.IntegrationFlow;\n" +
-                                "import org.springframework.integration.dsl.IntegrationFlows;\n" +
-                                "import org.springframework.integration.handler.LoggingHandler;\n" +
-                                "import org.springframework.integration.http.dsl.Http;\n" +
-                                "\n" +
-                                "@Configuration\n" +
-                                "public class FlowConfigurations {\n" +
-                                "    @Bean\n" +
-                                "    IntegrationFlow dwlFlow() {\n" +
-                                "        return IntegrationFlows.from(Http.inboundChannelAdapter(\"/dwl\")).handle((p, h) -> p)\n" +
-                                "                .log(LoggingHandler.Level.INFO, \"payload to be sent: #[new String(payload)]\")\n" +
-                                "                .handle((p, h) -> {\n" +
-                                "                    TmDwPayload dwPayload = new TmDwPayload();\n" +
-                                "                    String contentType = \"application/json\";\n" +
-                                "                    if (h.get(\"contentType\") != null) {\n" +
-                                "                        contentType = h.get(\"contentType\").toString();\n" +
-                                "                    }\n" +
-                                "                    dwPayload.setId(h.getId().toString());\n" +
-                                "                    dwPayload.setSourceType(contentType);\n" +
-                                "                    dwPayload.setSource(h.get(\"http_requestUrl\").toString());\n" +
-                                "                    dwPayload.setPayload(p.toString());\n" +
-                                "                    return dwPayload;\n" +
-                                "                })\n" +
-                                "                .transform(DwlFlowTransformTM_2::transform)\n" +
-                                "                .log(LoggingHandler.Level.INFO, \"payload to be sent: #[new String(payload)]\")\n" +
-                                "                .get();\n" +
-                                "    }\n" +
-                                "}");
+                .isEqualTo("""
+                                   package com.example.javadsl;
+                                   import org.springframework.context.annotation.Bean;
+                                   import org.springframework.context.annotation.Configuration;
+                                   import org.springframework.integration.dsl.IntegrationFlow;
+                                   import org.springframework.integration.dsl.IntegrationFlows;
+                                   import org.springframework.integration.handler.LoggingHandler;
+                                   import org.springframework.integration.http.dsl.Http;
+                                                                      
+                                   @Configuration
+                                   public class FlowConfigurations {
+                                       @Bean
+                                       IntegrationFlow dwlFlow() {
+                                           return IntegrationFlows.from(Http.inboundChannelAdapter("/dwl")).handle((p, h) -> p)
+                                                   .log(LoggingHandler.Level.INFO, "payload to be sent: #[new String(payload)]")
+                                                   .handle((p, h) -> {
+                                                       TmDwPayload dwPayload = new TmDwPayload();
+                                                       String contentType = "application/json";
+                                                       if (h.get("contentType") != null) {
+                                                           contentType = h.get("contentType").toString();
+                                                       }
+                                                       dwPayload.setId(h.getId().toString());
+                                                       dwPayload.setSourceType(contentType);
+                                                       dwPayload.setSource(h.get("http_requestUrl").toString());
+                                                       dwPayload.setPayload(p.toString());
+                                                       return dwPayload;
+                                                   })
+                                                   .transform(DwlFlowTransformTM_2::transform)
+                                                   .log(LoggingHandler.Level.INFO, "payload to be sent: #[new String(payload)]")
+                                                   .get();
+                                       }
+                                   }""");
         assertThat(projectContext.getProjectJavaSources().list().get(1).print())
-                .isEqualTo(
-                        "package com.example.javadsl;\n" +
-                                "import org.springframework.context.annotation.Configuration;\n" +
-                                "\n" +
-                                "import lombok.Data;\n" +
-                                "\n" +
-                                "/* Included with the baseline to support bridging between the Flow configuration and the translation implementation. */\n" +
-                                "\n" +
-                                "@Data\n" +
-                                "public class TmDwPayload {\n" +
-                                "    private String id;\n" +
-                                "    private String source;\n" +
-                                "    private String sourceType;\n" +
-                                "    private String payload;\n" +
-                                "}\n"
+                .isEqualTo("""
+                                   package com.example.javadsl;
+                                   import org.springframework.context.annotation.Configuration;
+                                                                      
+                                   import lombok.Data;
+                                                                      
+                                   /* Included with the baseline to support bridging between the Flow configuration and the translation implementation. */
+                                                                      
+                                   @Data
+                                   public class TmDwPayload {
+                                       private String id;
+                                       private String source;
+                                       private String sourceType;
+                                       private String payload;
+                                   }
+                                   """
                 );
         assertThat(projectContext.getProjectJavaSources().list().get(2).print())
-                .isEqualTo("package com.example.javadsl;\n" +
-                        "\n" +
-                        "import com.fasterxml.jackson.databind.ObjectMapper;\n" +
-                        "\n" +
-                        "import java.net.URI;\n" +
-                        "import java.net.http.HttpClient;\n" +
-                        "import java.net.http.HttpRequest;\n" +
-                        "import java.net.http.HttpResponse;\n" +
-                        "\n" +
-                        "public class DwlFlowTransformTM_2 {\n" +
-                        "    public static class DataWeavePayload {\n" +
-                        "        public String input_data;\n" +
-                        "        public String spell;\n" +
-                        "        public String input_content_type;\n" +
-                        "        public String output_content_type;\n" +
-                        "    };\n" +
-                        "\n" +
-                        "    public static String transform(TmDwPayload payload) {\n" +
-                        "        String uuid = payload.getId();\n" +
-                        "        String url = System.getenv(\"K_SINK\");\n" +
-                        "        HttpClient client = HttpClient.newHttpClient();\n" +
-                        "        HttpRequest.Builder requestBuilder;\n" +
-                        "        DataWeavePayload dwPayload = new DataWeavePayload();\n" +
-                        "\n" +
-                        "        if (payload.getSourceType().contains(\";\")) {\n" +
-                        "            dwPayload.input_content_type = payload.getSourceType().split(\";\")[0];\n" +
-                        "        } else {\n" +
-                        "            dwPayload.input_content_type = payload.getSourceType();\n" +
-                        "        }\n" +
-                        "        dwPayload.output_content_type = \"application/json\";\n" +
-                        "\n" +
-                        "        //TODO: Verify the spell conforms to Dataweave 2.x: https://docs.mulesoft.com/mule-runtime/4.4/migration-dataweave\n" +
-                        "        dwPayload.spell = \"%dw 1.0\\n%output application/json\\n---\\n{\\n    action_Code: 10,\\n    returnCode:  20\\n}\";\n" +
-                        "        dwPayload.input_data = payload.getPayload();\n" +
-                        "        String body;\n" +
-                        "\n" +
-                        "        try {\n" +
-                        "            requestBuilder = HttpRequest.newBuilder(new URI(url));\n" +
-                        "            ObjectMapper om = new ObjectMapper();\n" +
-                        "            body = om.writeValueAsString(dwPayload);\n" +
-                        "        } catch (Exception e) {\n" +
-                        "            System.out.println(\"Error sending request: \" + e.toString());\n" +
-                        "            return null;\n" +
-                        "        }\n" +
-                        "\n" +
-                        "        requestBuilder.setHeader(\"content-type\", \"application/json\");\n" +
-                        "        requestBuilder.setHeader(\"ce-specversion\", \"1.0\");\n" +
-                        "        requestBuilder.setHeader(\"ce-source\", payload.getSource());\n" +
-                        "        requestBuilder.setHeader(\"ce-type\", \"io.triggermesh.dataweave.transform\");\n" +
-                        "        requestBuilder.setHeader(\"ce-id\", payload.getId());\n" +
-                        "\n" +
-                        "        HttpRequest request = requestBuilder.POST(HttpRequest.BodyPublishers.ofString(body)).build();\n" +
-                        "\n" +
-                        "        try {\n" +
-                        "            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());\n" +
-                        "            // TODO: verify the response status and body\n" +
-                        "            return response.body();\n" +
-                        "        } catch (Exception e) {\n" +
-                        "            System.out.println(\"Error sending event: \" + e.toString());\n" +
-                        "            return null;\n" +
-                        "        }\n" +
-                        "    }\n" +
-                        "}\n");
+                .isEqualTo("""
+                                   package com.example.javadsl;
+                                                                      
+                                   import com.fasterxml.jackson.databind.ObjectMapper;
+                                                                      
+                                   import java.net.URI;
+                                   import java.net.http.HttpClient;
+                                   import java.net.http.HttpRequest;
+                                   import java.net.http.HttpResponse;
+                                                                      
+                                   public class DwlFlowTransformTM_2 {
+                                       public static class DataWeavePayload {
+                                           public String input_data;
+                                           public String spell;
+                                           public String input_content_type;
+                                           public String output_content_type;
+                                       };
+                                                                      
+                                       public static String transform(TmDwPayload payload) {
+                                           String uuid = payload.getId();
+                                           String url = System.getenv("K_SINK");
+                                           HttpClient client = HttpClient.newHttpClient();
+                                           HttpRequest.Builder requestBuilder;
+                                           DataWeavePayload dwPayload = new DataWeavePayload();
+                                                                      
+                                           if (payload.getSourceType().contains(";")) {
+                                               dwPayload.input_content_type = payload.getSourceType().split(";")[0];
+                                           } else {
+                                               dwPayload.input_content_type = payload.getSourceType();
+                                           }
+                                           dwPayload.output_content_type = "application/json";
+                                                                      
+                                           //TODO: Verify the spell conforms to Dataweave 2.x: https://docs.mulesoft.com/mule-runtime/4.4/migration-dataweave
+                                           dwPayload.spell = "%dw 1.0\\n%output application/json\\n---\\n{\\n    action_Code: 10,\\n    returnCode:  20\\n}";
+                                           dwPayload.input_data = payload.getPayload();
+                                           String body;
+                                                                      
+                                           try {
+                                               requestBuilder = HttpRequest.newBuilder(new URI(url));
+                                               ObjectMapper om = new ObjectMapper();
+                                               body = om.writeValueAsString(dwPayload);
+                                           } catch (Exception e) {
+                                               System.out.println("Error sending request: " + e.toString());
+                                               return null;
+                                           }
+                                                                      
+                                           requestBuilder.setHeader("content-type", "application/json");
+                                           requestBuilder.setHeader("ce-specversion", "1.0");
+                                           requestBuilder.setHeader("ce-source", payload.getSource());
+                                           requestBuilder.setHeader("ce-type", "io.triggermesh.dataweave.transform");
+                                           requestBuilder.setHeader("ce-id", payload.getId());
+                                                                      
+                                           HttpRequest request = requestBuilder.POST(HttpRequest.BodyPublishers.ofString(body)).build();
+                                                                      
+                                           try {
+                                               HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+                                               // TODO: verify the response status and body
+                                               return response.body();
+                                           } catch (Exception e) {
+                                               System.out.println("Error sending event: " + e.toString());
+                                               return null;
+                                           }
+                                       }
+                                   }
+                                   """);
     }
 
     @Test
     public void shouldTransformDWLWithFileWithSetPayload() {
-        final String dwlXMLWithExternalFile = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "\n" +
-                "<mule xmlns:dw=\"http://www.mulesoft.org/schema/mule/ee/dw\" xmlns:http=\"http://www.mulesoft.org/schema/mule/http\"\n" +
-                "      xmlns=\"http://www.mulesoft.org/schema/mule/core\" xmlns:doc=\"http://www.mulesoft.org/schema/mule/documentation\"\n" +
-                "      xmlns:spring=\"http://www.springframework.org/schema/beans\"\n" +
-                "      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
-                "      xsi:schemaLocation=\"http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd\n" +
-                "http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd\n" +
-                "http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd\n" +
-                "http://www.mulesoft.org/schema/mule/ee/dw http://www.mulesoft.org/schema/mule/ee/dw/current/dw.xsd\">\n" +
-                "    <flow name=\"dwlFlow\">\n" +
-                "        <http:listener config-ref=\"HTTP_Listener_Configuration\" path=\"/dwl\" doc:name=\"HTTP\"/>\n" +
-                "\n" +
-                "        <logger message=\"payload to be sent: #[new String(payload)]\" level=\"INFO\"\n" +
-                "                doc:name=\"Log the message content to be sent\"/>\n" +
-                "\n" +
-                "        <dw:transform-message doc:name=\"action transform via file\">\n" +
-                "            <dw:input-payload mimeType=\"text/plain\">\n" +
-                "                <dw:reader-property name=\"schemaPath\" value=\"schemas/MQOutput.ffd\"/>\n" +
-                "            </dw:input-payload>\n" +
-                "            <dw:set-payload resource=\"classpath:dwl/mapClientRiskRatingResponse.dwl\"/>\n" +
-                "        </dw:transform-message>\n" +
-                "\n" +
-                "        <logger message=\"payload to be sent: #[new String(payload)]\" level=\"INFO\"\n" +
-                "                doc:name=\"Log the message content to be sent\"/>\n" +
-                "    </flow>\n" +
-                "</mule>";
+        final String dwlXMLWithExternalFile = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                                
+                <mule xmlns:dw="http://www.mulesoft.org/schema/mule/ee/dw" xmlns:http="http://www.mulesoft.org/schema/mule/http"
+                      xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+                      xmlns:spring="http://www.springframework.org/schema/beans"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+                http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+                http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+                http://www.mulesoft.org/schema/mule/ee/dw http://www.mulesoft.org/schema/mule/ee/dw/current/dw.xsd">
+                    <flow name="dwlFlow">
+                        <http:listener config-ref="HTTP_Listener_Configuration" path="/dwl" doc:name="HTTP"/>
+                                
+                        <logger message="payload to be sent: #[new String(payload)]" level="INFO"
+                                doc:name="Log the message content to be sent"/>
+                                
+                        <dw:transform-message doc:name="action transform via file">
+                            <dw:input-payload mimeType="text/plain">
+                                <dw:reader-property name="schemaPath" value="schemas/MQOutput.ffd"/>
+                            </dw:input-payload>
+                            <dw:set-payload resource="classpath:dwl/mapClientRiskRatingResponse.dwl"/>
+                        </dw:transform-message>
+                                
+                        <logger message="payload to be sent: #[new String(payload)]" level="INFO"
+                                doc:name="Log the message content to be sent"/>
+                    </flow>
+                </mule>
+                """;
         addXMLFileToResource(dwlXMLWithExternalFile);
         runAction();
         assertThat(projectContext.getProjectJavaSources().list()).hasSize(2);
         assertThat(getGeneratedJavaFile())
-                .isEqualTo(
-                        "package com.example.javadsl;\n" +
-                                "import org.springframework.context.annotation.Bean;\n" +
-                                "import org.springframework.context.annotation.Configuration;\n" +
-                                "import org.springframework.integration.dsl.IntegrationFlow;\n" +
-                                "import org.springframework.integration.dsl.IntegrationFlows;\n" +
-                                "import org.springframework.integration.handler.LoggingHandler;\n" +
-                                "import org.springframework.integration.http.dsl.Http;\n" +
-                                "\n" +
-                                "@Configuration\n" +
-                                "public class FlowConfigurations {\n" +
-                                "    @Bean\n" +
-                                "    IntegrationFlow dwlFlow() {\n" +
-                                "        return IntegrationFlows.from(Http.inboundChannelAdapter(\"/dwl\")).handle((p, h) -> p)\n" +
-                                "                .log(LoggingHandler.Level.INFO, \"payload to be sent: #[new String(payload)]\")\n" +
-                                "                .transform(MapClientRiskRatingResponseTransform::transform)\n" +
-                                "                .log(LoggingHandler.Level.INFO, \"payload to be sent: #[new String(payload)]\")\n" +
-                                "                .get();\n" +
-                                "    }\n" +
-                                "}");
+                .isEqualTo("""
+                                   package com.example.javadsl;
+                                   import org.springframework.context.annotation.Bean;
+                                   import org.springframework.context.annotation.Configuration;
+                                   import org.springframework.integration.dsl.IntegrationFlow;
+                                   import org.springframework.integration.dsl.IntegrationFlows;
+                                   import org.springframework.integration.handler.LoggingHandler;
+                                   import org.springframework.integration.http.dsl.Http;
+                                                                      
+                                   @Configuration
+                                   public class FlowConfigurations {
+                                       @Bean
+                                       IntegrationFlow dwlFlow() {
+                                           return IntegrationFlows.from(Http.inboundChannelAdapter("/dwl")).handle((p, h) -> p)
+                                                   .log(LoggingHandler.Level.INFO, "payload to be sent: #[new String(payload)]")
+                                                   .transform(MapClientRiskRatingResponseTransform::transform)
+                                                   .log(LoggingHandler.Level.INFO, "payload to be sent: #[new String(payload)]")
+                                                   .get();
+                                       }
+                                   }""");
         assertThat(projectContext.getProjectJavaSources().list().get(1).print())
-                .isEqualTo(
-                        "package com.example.javadsl;\n" +
-                                "\n" +
-                                "public class MapClientRiskRatingResponseTransform {\n" +
-                                "    /*\n" +
-                                "     * TODO:\n" +
-                                "     *\n" +
-                                "     * Please add necessary transformation for below snippet\n" +
-                                "     * from file dwl/mapClientRiskRatingResponse.dwl" +
-                                "     * */\n" +
-                                "    public static MapClientRiskRatingResponseTransform transform(Object payload) {\n" +
-                                "\n" +
-                                "        return new MapClientRiskRatingResponseTransform();\n" +
-                                "    }\n" +
-                                "}");
+                .isEqualTo("""
+                                   package com.example.javadsl;
+                                                                      
+                                   public class MapClientRiskRatingResponseTransform {
+                                       /*
+                                        * TODO:
+                                        *
+                                        * Please add necessary transformation for below snippet
+                                        * from file dwl/mapClientRiskRatingResponse.dwl     * */
+                                       public static MapClientRiskRatingResponseTransform transform(Object payload) {
+                                                                      
+                                           return new MapClientRiskRatingResponseTransform();
+                                       }
+                                   }""");
     }
 
     @Test
     public void shouldTranslateDWLTransformationWithOnlyOneSetVariable() {
-        String muleXMLSetVariable = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "\n" +
-                "<mule xmlns:dw=\"http://www.mulesoft.org/schema/mule/ee/dw\" xmlns:http=\"http://www.mulesoft.org/schema/mule/http\" xmlns=\"http://www.mulesoft.org/schema/mule/core\" xmlns:doc=\"http://www.mulesoft.org/schema/mule/documentation\"\n" +
-                "    xmlns:spring=\"http://www.springframework.org/schema/beans\" \n" +
-                "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
-                "    xsi:schemaLocation=\"http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd\n" +
-                "http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd\n" +
-                "http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd\n" +
-                "http://www.mulesoft.org/schema/mule/ee/dw http://www.mulesoft.org/schema/mule/ee/dw/current/dw.xsd\">\n" +
-                "    <flow name=\"dwlFlow\">\n" +
-                "        <http:listener config-ref=\"HTTP_Listener_Configuration\" path=\"/dwl\" doc:name=\"HTTP\"/>\n" +
-                "    \n" +
-                "        <dw:transform-message doc:name=\"action transform\">\n" +
-                "        <dw:set-variable variableName=\"temp\"><![CDATA[%dw 1.0\n" +
-                "%output application/json\n" +
-                "---\n" +
-                "{\n" +
-                "    action_Code: 10,\n" +
-                "    returnCode:  20\n" +
-                "}]]>\n" +
-                "        \n" +
-                "        </dw:set-variable>\n" +
-                "        </dw:transform-message>\n" +
-                "        \n" +
-                "         <logger message=\"Hello World:  #[flowVars.temp]\" level=\"INFO\" doc:name=\"Log the message content to be sent\"/>\n" +
-                "    </flow>\n" +
-                "</mule>";
+        String muleXMLSetVariable = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                                
+                <mule xmlns:dw="http://www.mulesoft.org/schema/mule/ee/dw" xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+                    xmlns:spring="http://www.springframework.org/schema/beans"\s
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+                http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+                http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+                http://www.mulesoft.org/schema/mule/ee/dw http://www.mulesoft.org/schema/mule/ee/dw/current/dw.xsd">
+                    <flow name="dwlFlow">
+                        <http:listener config-ref="HTTP_Listener_Configuration" path="/dwl" doc:name="HTTP"/>
+                
+                        <dw:transform-message doc:name="action transform">
+                        <dw:set-variable variableName="temp"><![CDATA[%dw 1.0
+                %output application/json
+                ---
+                {
+                    action_Code: 10,
+                    returnCode:  20
+                }]]>
+                    
+                        </dw:set-variable>
+                        </dw:transform-message>
+                    
+                         <logger message="Hello World:  #[flowVars.temp]" level="INFO" doc:name="Log the message content to be sent"/>
+                    </flow>
+                </mule>
+                """;
         addXMLFileToResource(muleXMLSetVariable);
         runAction();
         assertThat(projectContext.getProjectJavaSources().list()).hasSize(1);
         assertThat(getGeneratedJavaFile())
-                .isEqualTo(
-                        "package com.example.javadsl;\n" +
-                                "import org.springframework.context.annotation.Bean;\n" +
-                                "import org.springframework.context.annotation.Configuration;\n" +
-                                "import org.springframework.integration.dsl.IntegrationFlow;\n" +
-                                "import org.springframework.integration.dsl.IntegrationFlows;\n" +
-                                "import org.springframework.integration.handler.LoggingHandler;\n" +
-                                "import org.springframework.integration.http.dsl.Http;\n" +
-                                "\n" +
-                                "@Configuration\n" +
-                                "public class FlowConfigurations {\n" +
-                                "    @Bean\n" +
-                                "    IntegrationFlow dwlFlow() {\n" +
-                                "        return IntegrationFlows.from(Http.inboundChannelAdapter(\"/dwl\")).handle((p, h) -> p)\n" +
-                                "                // FIXME: No support for following DW transformation: <dw:set-property/> <dw:set-session-variable /> <dw:set-variable />\n" +
-                                "                .log(LoggingHandler.Level.INFO, \"Hello World:  ${flowVars.temp}\")\n" +
-                                "                .get();\n" +
-                                "    }\n" +
-                                "}");
+                .isEqualTo("""
+                                   package com.example.javadsl;
+                                   import org.springframework.context.annotation.Bean;
+                                   import org.springframework.context.annotation.Configuration;
+                                   import org.springframework.integration.dsl.IntegrationFlow;
+                                   import org.springframework.integration.dsl.IntegrationFlows;
+                                   import org.springframework.integration.handler.LoggingHandler;
+                                   import org.springframework.integration.http.dsl.Http;
+                                                                      
+                                   @Configuration
+                                   public class FlowConfigurations {
+                                       @Bean
+                                       IntegrationFlow dwlFlow() {
+                                           return IntegrationFlows.from(Http.inboundChannelAdapter("/dwl")).handle((p, h) -> p)
+                                                   // FIXME: No support for following DW transformation: <dw:set-property/> <dw:set-session-variable /> <dw:set-variable />
+                                                   .log(LoggingHandler.Level.INFO, "Hello World:  ${flowVars.temp}")
+                                                   .get();
+                                       }
+                                   }""");
     }
 
     @Test
     public void shouldNotErrorWhenDWLFileHasDash() {
-        final String dwlExternalFileSpecialChars = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
-                "\n" +
-                "<mule xmlns:dw=\"http://www.mulesoft.org/schema/mule/ee/dw\" xmlns:http=\"http://www.mulesoft.org/schema/mule/http\"\n" +
-                "      xmlns=\"http://www.mulesoft.org/schema/mule/core\" xmlns:doc=\"http://www.mulesoft.org/schema/mule/documentation\"\n" +
-                "      xmlns:spring=\"http://www.springframework.org/schema/beans\"\n" +
-                "      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
-                "      xsi:schemaLocation=\"http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd\n" +
-                "http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd\n" +
-                "http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd\n" +
-                "http://www.mulesoft.org/schema/mule/ee/dw http://www.mulesoft.org/schema/mule/ee/dw/current/dw.xsd\">\n" +
-                "    <flow name=\"dwlFlow\">\n" +
-                "        <http:listener config-ref=\"HTTP_Listener_Configuration\" path=\"/dwl\" doc:name=\"HTTP\"/>\n" +
-                "\n" +
-                "        <logger message=\"payload to be sent: #[new String(payload)]\" level=\"INFO\"\n" +
-                "                doc:name=\"Log the message content to be sent\"/>\n" +
-                "\n" +
-                "        <dw:transform-message doc:name=\"action transform via file\">\n" +
-                "            <dw:input-payload mimeType=\"text/plain\">\n" +
-                "                <dw:reader-property name=\"schemaPath\" value=\"schemas/MQOutput.ffd\"/>\n" +
-                "            </dw:input-payload>\n" +
-                "            <dw:set-payload resource=\"classpath:dwl/map-client-risk-rating-response.dwl\"/>\n" +
-                "        </dw:transform-message>\n" +
-                "\n" +
-                "        <logger message=\"payload to be sent: #[new String(payload)]\" level=\"INFO\"\n" +
-                "                doc:name=\"Log the message content to be sent\"/>\n" +
-                "    </flow>\n" +
-                "</mule>";
+        final String dwlExternalFileSpecialChars = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                                
+                <mule xmlns:dw="http://www.mulesoft.org/schema/mule/ee/dw" xmlns:http="http://www.mulesoft.org/schema/mule/http"
+                      xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+                      xmlns:spring="http://www.springframework.org/schema/beans"
+                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                      xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+                http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+                http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+                http://www.mulesoft.org/schema/mule/ee/dw http://www.mulesoft.org/schema/mule/ee/dw/current/dw.xsd">
+                    <flow name="dwlFlow">
+                        <http:listener config-ref="HTTP_Listener_Configuration" path="/dwl" doc:name="HTTP"/>
+                                
+                        <logger message="payload to be sent: #[new String(payload)]" level="INFO"
+                                doc:name="Log the message content to be sent"/>
+                                
+                        <dw:transform-message doc:name="action transform via file">
+                            <dw:input-payload mimeType="text/plain">
+                                <dw:reader-property name="schemaPath" value="schemas/MQOutput.ffd"/>
+                            </dw:input-payload>
+                            <dw:set-payload resource="classpath:dwl/map-client-risk-rating-response.dwl"/>
+                        </dw:transform-message>
+                                
+                        <logger message="payload to be sent: #[new String(payload)]" level="INFO"
+                                doc:name="Log the message content to be sent"/>
+                    </flow>
+                </mule>
+                """;
         addXMLFileToResource(dwlExternalFileSpecialChars);
         runAction();
         assertThat(projectContext.getProjectJavaSources().list()).hasSize(2);
         assertThat(getGeneratedJavaFile())
-                .isEqualTo(
-                        "package com.example.javadsl;\n" +
-                                "import org.springframework.context.annotation.Bean;\n" +
-                                "import org.springframework.context.annotation.Configuration;\n" +
-                                "import org.springframework.integration.dsl.IntegrationFlow;\n" +
-                                "import org.springframework.integration.dsl.IntegrationFlows;\n" +
-                                "import org.springframework.integration.handler.LoggingHandler;\n" +
-                                "import org.springframework.integration.http.dsl.Http;\n" +
-                                "\n" +
-                                "@Configuration\n" +
-                                "public class FlowConfigurations {\n" +
-                                "    @Bean\n" +
-                                "    IntegrationFlow dwlFlow() {\n" +
-                                "        return IntegrationFlows.from(Http.inboundChannelAdapter(\"/dwl\")).handle((p, h) -> p)\n" +
-                                "                .log(LoggingHandler.Level.INFO, \"payload to be sent: #[new String(payload)]\")\n" +
-                                "                .transform(MapclientriskratingresponseTransform::transform)\n" +
-                                "                .log(LoggingHandler.Level.INFO, \"payload to be sent: #[new String(payload)]\")\n" +
-                                "                .get();\n" +
-                                "    }\n" +
-                                "}");
+                .isEqualTo("""
+                                   package com.example.javadsl;
+                                   import org.springframework.context.annotation.Bean;
+                                   import org.springframework.context.annotation.Configuration;
+                                   import org.springframework.integration.dsl.IntegrationFlow;
+                                   import org.springframework.integration.dsl.IntegrationFlows;
+                                   import org.springframework.integration.handler.LoggingHandler;
+                                   import org.springframework.integration.http.dsl.Http;
+                                                                      
+                                   @Configuration
+                                   public class FlowConfigurations {
+                                       @Bean
+                                       IntegrationFlow dwlFlow() {
+                                           return IntegrationFlows.from(Http.inboundChannelAdapter("/dwl")).handle((p, h) -> p)
+                                                   .log(LoggingHandler.Level.INFO, "payload to be sent: #[new String(payload)]")
+                                                   .transform(MapclientriskratingresponseTransform::transform)
+                                                   .log(LoggingHandler.Level.INFO, "payload to be sent: #[new String(payload)]")
+                                                   .get();
+                                       }
+                                   }""");
         assertThat(projectContext.getProjectJavaSources().list().get(1).print())
-                .isEqualTo(
-                        "package com.example.javadsl;\n" +
-                                "\n" +
-                                "public class MapclientriskratingresponseTransform {\n" +
-                                "    /*\n" +
-                                "     * TODO:\n" +
-                                "     *\n" +
-                                "     * Please add necessary transformation for below snippet\n" +
-                                "     * from file dwl/map-client-risk-rating-response.dwl     * */\n" +
-                                "    public static MapclientriskratingresponseTransform transform(Object payload) {\n" +
-                                "\n" +
-                                "        return new MapclientriskratingresponseTransform();\n" +
-                                "    }\n" +
-                                "}");
+                .isEqualTo("""
+                                   package com.example.javadsl;
+                                                                      
+                                   public class MapclientriskratingresponseTransform {
+                                       /*
+                                        * TODO:
+                                        *
+                                        * Please add necessary transformation for below snippet
+                                        * from file dwl/map-client-risk-rating-response.dwl     * */
+                                       public static MapclientriskratingresponseTransform transform(Object payload) {
+                                                                      
+                                           return new MapclientriskratingresponseTransform();
+                                       }
+                                   }""");
     }
 
     @Test
     public void multipleDWLTransformInSameFlowShouldProduceMultipleClasses() {
-        final String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>    " +
-                "<mule xmlns:dw=\"http://www.mulesoft.org/schema/mule/ee/dw\" xmlns=\"http://www.mulesoft.org/schema/mule/core\" xmlns:doc=\"http://www.mulesoft.org/schema/mule/documentation\"    " +
-                "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"    " +
-                "    xsi:schemaLocation=\"http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd    " +
-                "http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd    " +
-                "http://www.mulesoft.org/schema/mule/db http://www.mulesoft.org/schema/mule/db/current/mule-db.xsd    " +
-                "http://www.mulesoft.org/schema/mule/ee/dw http://www.mulesoft.org/schema/mule/ee/dw/current/dw.xsd\">    " +
-                "    <flow name=\"multipleTransforms\">    " +
-                "        <dw:transform-message doc:name=\"Transform Message\">    " +
-                "            <dw:set-payload><![CDATA[%dw 1.0    " +
-                "%output application/json indent = true, skipNullOn = \"everywhere\"    " +
-                "---    " +
-                "{    " +
-                "    \"hello\": {    " +
-                "        \"world\": {    " +
-                "            \"hello\": \"indeed!\",    " +
-                "        },    " +
-                "    }    " +
-                "}]]></dw:set-payload>    " +
-                "        </dw:transform-message>    " +
-                "        <logger />    " +
-                "        <dw:transform-message doc:name=\"Build Response Message\">    " +
-                "            <dw:set-payload><![CDATA[%dw 1.0    " +
-                "%output application/json indent = true, skipNullOn = \"everywhere\"    " +
-                "---    " +
-                "{    " +
-                "    \"responseBody\": {    " +
-                "        \"responseInfo\": {    " +
-                "            \"responseStatus\": \"200\"    " +
-                "        },    " +
-                "    }    " +
-                "}]]></dw:set-payload>    " +
-                "        </dw:transform-message>    " +
-                "    </flow>    " +
-                "</mule>";
+        final String xml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <mule xmlns:dw="http://www.mulesoft.org/schema/mule/ee/dw" xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+                http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+                http://www.mulesoft.org/schema/mule/db http://www.mulesoft.org/schema/mule/db/current/mule-db.xsd
+                http://www.mulesoft.org/schema/mule/ee/dw http://www.mulesoft.org/schema/mule/ee/dw/current/dw.xsd">
+                    <flow name="multipleTransforms">
+                        <dw:transform-message doc:name="Transform Message">
+                            <dw:set-payload><![CDATA[%dw 1.0
+                %output application/json indent = true, skipNullOn = "everywhere"
+                ---
+                {
+                    "hello": {
+                        "world": {
+                            "hello": "indeed!",
+                        },
+                    }
+                }]]></dw:set-payload>
+                        </dw:transform-message>
+                        <logger />
+                        <dw:transform-message doc:name="Build Response Message">
+                            <dw:set-payload><![CDATA[%dw 1.0
+                %output application/json indent = true, skipNullOn = "everywhere"
+                ---
+                {
+                    "responseBody": {
+                        "responseInfo": {
+                            "responseStatus": "200"
+                        },
+                    }
+                }]]></dw:set-payload>
+                        </dw:transform-message>
+                    </flow>
+                </mule>
+                """;
 
         addXMLFileToResource(xml);
         runAction();
 
         assertThat(projectContext.getProjectJavaSources().list()).hasSize(3);
         assertThat(projectContext.getProjectJavaSources().list().get(0).getTypes().get(0).toString()).isEqualTo("com.example.javadsl.FlowConfigurations");
-        assertThat(projectContext.getProjectJavaSources().list().get(1).getTypes().get(0).toString()).isEqualTo("com.example.javadsl.MultipleTransformsTransform_2");
-        assertThat(projectContext.getProjectJavaSources().list().get(2).getTypes().get(0).toString()).isEqualTo("com.example.javadsl.MultipleTransformsTransform_0");
+        assertThat(projectContext.getProjectJavaSources().list().get(2).getTypes().get(0).toString()).isEqualTo("com.example.javadsl.MultipleTransformsTransform_2");
+        assertThat(projectContext.getProjectJavaSources().list().get(1).getTypes().get(0).toString()).isEqualTo("com.example.javadsl.MultipleTransformsTransform_0");
     }
 
     @Test
     public void multipleDWLTransformInSameFlowShouldProduceMultipleClassesWithTriggerMeshEnabled() {
         enableTriggerMeshTransform();
 
-        final String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>    " +
-                "<mule xmlns:dw=\"http://www.mulesoft.org/schema/mule/ee/dw\" xmlns=\"http://www.mulesoft.org/schema/mule/core\" xmlns:doc=\"http://www.mulesoft.org/schema/mule/documentation\"    " +
-                "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"    " +
-                "    xsi:schemaLocation=\"http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd    " +
-                "http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd    " +
-                "http://www.mulesoft.org/schema/mule/db http://www.mulesoft.org/schema/mule/db/current/mule-db.xsd    " +
-                "http://www.mulesoft.org/schema/mule/ee/dw http://www.mulesoft.org/schema/mule/ee/dw/current/dw.xsd\">    " +
-                "    <flow name=\"multipleTransforms\">    " +
-                "        <dw:transform-message doc:name=\"Transform Message\">    " +
-                "            <dw:set-payload><![CDATA[%dw 1.0    " +
-                "%output application/json indent = true, skipNullOn = \"everywhere\"    " +
-                "---    " +
-                "{    " +
-                "    \"hello\": {    " +
-                "        \"world\": {    " +
-                "            \"hello\": \"indeed!\",    " +
-                "        },    " +
-                "    }    " +
-                "}]]></dw:set-payload>    " +
-                "        </dw:transform-message>    " +
-                "        <logger />    " +
-                "        <dw:transform-message doc:name=\"Build Response Message\">    " +
-                "            <dw:set-payload><![CDATA[%dw 1.0    " +
-                "%output application/json indent = true, skipNullOn = \"everywhere\"    " +
-                "---    " +
-                "{    " +
-                "    \"responseBody\": {    " +
-                "        \"responseInfo\": {    " +
-                "            \"responseStatus\": \"200\"    " +
-                "        },    " +
-                "    }    " +
-                "}]]></dw:set-payload>    " +
-                "        </dw:transform-message>    " +
-                "    </flow>    " +
-                "</mule>";
+        final String xml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <mule xmlns:dw="http://www.mulesoft.org/schema/mule/ee/dw" xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd
+                http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+                http://www.mulesoft.org/schema/mule/db http://www.mulesoft.org/schema/mule/db/current/mule-db.xsd
+                http://www.mulesoft.org/schema/mule/ee/dw http://www.mulesoft.org/schema/mule/ee/dw/current/dw.xsd">
+                    <flow name="multipleTransforms">
+                        <dw:transform-message doc:name="Transform Message">
+                            <dw:set-payload><![CDATA[%dw 1.0
+                %output application/json indent = true, skipNullOn = "everywhere"
+                ---
+                {
+                    "hello": {
+                        "world": {
+                            "hello": "indeed!",
+                        },
+                    }
+                }]]></dw:set-payload>
+                        </dw:transform-message>
+                        <logger />
+                        <dw:transform-message doc:name="Build Response Message">
+                            <dw:set-payload><![CDATA[%dw 1.0
+                %output application/json indent = true, skipNullOn = "everywhere"
+                ---
+                {
+                    "responseBody": {
+                        "responseInfo": {
+                            "responseStatus": "200"
+                        },
+                    }
+                }]]></dw:set-payload>
+                        </dw:transform-message>
+                    </flow>
+                </mule>
+                """;
 
         addXMLFileToResource(xml);
         runAction();

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLDwlTransformTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/MuleToJavaDSLDwlTransformTest.java
@@ -21,6 +21,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class MuleToJavaDSLDwlTransformTest extends JavaDSLActionBaseTest {
 
+    // workaround to force-enable the TriggerMesh transform mode
+    private void enableTriggerMeshTransform() {
+        myAction.setMuleTriggerMeshTransformEnabled(true);
+        System.setProperty("sbm.muleTriggerMeshTransformEnabled", "true");
+    }
+
     private static final String muleXmlSetPayload = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
             "\n" +
             "<mule xmlns:dw=\"http://www.mulesoft.org/schema/mule/ee/dw\" xmlns:http=\"http://www.mulesoft.org/schema/mule/http\" xmlns=\"http://www.mulesoft.org/schema/mule/core\" xmlns:doc=\"http://www.mulesoft.org/schema/mule/documentation\"\n" +
@@ -97,6 +103,125 @@ public class MuleToJavaDSLDwlTransformTest extends JavaDSLActionBaseTest {
                                 "        return new DwlFlowTransform_2();\n" +
                                 "    }\n" +
                                 "}");
+    }
+
+    @Test
+    public void shouldTranslateDwlTransformationWithMuleTriggerMeshTransformAndSetPayloadEnabled() {
+        enableTriggerMeshTransform();
+        addXMLFileToResource(muleXmlSetPayload);
+        runAction();
+
+        assertThat(projectContext.getProjectJavaSources().list()).hasSize(3);
+        assertThat(getGeneratedJavaFile())
+                .isEqualTo(
+                        "package com.example.javadsl;\n" +
+                                "import org.springframework.context.annotation.Bean;\n" +
+                                "import org.springframework.context.annotation.Configuration;\n" +
+                                "import org.springframework.integration.dsl.IntegrationFlow;\n" +
+                                "import org.springframework.integration.dsl.IntegrationFlows;\n" +
+                                "import org.springframework.integration.handler.LoggingHandler;\n" +
+                                "import org.springframework.integration.http.dsl.Http;\n" +
+                                "\n" +
+                                "@Configuration\n" +
+                                "public class FlowConfigurations {\n" +
+                                "    @Bean\n" +
+                                "    IntegrationFlow dwlFlow() {\n" +
+                                "        return IntegrationFlows.from(Http.inboundChannelAdapter(\"/dwl\")).handle((p, h) -> p)\n" +
+                                "                .log(LoggingHandler.Level.INFO, \"payload to be sent: #[new String(payload)]\")\n" +
+                                "                .handle((p, h) -> {\n" +
+                                "                    TmDwPayload dwPayload = new TmDwPayload();\n" +
+                                "                    dwPayload.setId(h.getId().toString());\n" +
+                                "                    dwPayload.setSourceType(h.get(\"contentType\").toString());\n" +
+                                "                    dwPayload.setSource(h.get(\"http_requestUrl\").toString());\n" +
+                                "                    dwPayload.setPayload(p.toString());\n" +
+                                "                    return dwPayload;\n" +
+                                "                })\n" +
+                                "                .transform(DwlFlowTransformTM_2::transform)\n" +
+                                "                .log(LoggingHandler.Level.INFO, \"payload to be sent: #[new String(payload)]\")\n" +
+                                "                .get();\n" +
+                                "    }\n" +
+                                "}");
+        assertThat(projectContext.getProjectJavaSources().list().get(1).print())
+                .isEqualTo(
+                        "package com.example.javadsl;\n" +
+                                "import org.springframework.context.annotation.Configuration;\n" +
+                                "\n" +
+                                "import lombok.Data;\n" +
+                                "\n" +
+                                "/* Included with the baseline to support bridging between the Flow configuration and the translation implementation. */\n" +
+                                "\n" +
+                                "@Data\n" +
+                                "public class TmDwPayload {\n" +
+                                "    private String id;\n" +
+                                "    private String source;\n" +
+                                "    private String sourceType;\n" +
+                                "    private String payload;\n" +
+                                "}\n"
+                );
+        assertThat(projectContext.getProjectJavaSources().list().get(2).print())
+                .isEqualTo("package com.example.javadsl;\n" +
+                        "\n" +
+                        "import com.fasterxml.jackson.databind.ObjectMapper;\n" +
+                        "\n" +
+                        "import java.net.URI;\n" +
+                        "import java.net.http.HttpClient;\n" +
+                        "import java.net.http.HttpRequest;\n" +
+                        "import java.net.http.HttpResponse;\n" +
+                        "\n" +
+                        "public class DwlFlowTransformTM_2 {\n" +
+                        "    public static class DataWeavePayload {\n" +
+                        "        public String input_data;\n" +
+                        "        public String spell;\n" +
+                        "        public String input_content_type;\n" +
+                        "        public String output_content_type;\n" +
+                        "    };\n" +
+                        "\n" +
+                        "    public static String transform(TmDwPayload payload) {\n" +
+                        "        String uuid = payload.getId();\n" +
+                        "        String url = System.getenv(\"K_SINK\");\n" +
+                        "        HttpClient client = HttpClient.newHttpClient();\n" +
+                        "        HttpRequest.Builder requestBuilder;\n" +
+                        "        DataWeavePayload dwPayload = new DataWeavePayload();\n" +
+                        "\n" +
+                        "        if (payload.getSourceType().contains(\";\")) {\n" +
+                        "            dwPayload.input_content_type = payload.getSourceType().split(\";\")[0];\n" +
+                        "        } else {\n" +
+                        "            dwPayload.input_content_type = payload.getSourceType();\n" +
+                        "        }\n" +
+                        "        dwPayload.output_content_type = \"application/json\";\n" +
+                        "\n" +
+                        "        //TODO: Verify the spell conforms to Dataweave 2.x: https://docs.mulesoft.com/mule-runtime/4.4/migration-dataweave\n" +
+                        "        dwPayload.spell = \"%dw 1.0\\n%output application/json\\n---\\n{\\n    action_Code: 10,\\n    returnCode:  20\\n}\";\n" +
+                        "        dwPayload.input_data = payload.getPayload();\n" +
+                        "        String body;\n" +
+                        "\n" +
+                        "        try {\n" +
+                        "            requestBuilder = HttpRequest.newBuilder(new URI(url));\n" +
+                        "            ObjectMapper om = new ObjectMapper();\n" +
+                        "            body = om.writeValueAsString(dwPayload);\n" +
+                        "        } catch (Exception e) {\n" +
+                        "            System.out.println(\"Error sending request: \" + e.toString());\n" +
+                        "            return null;\n" +
+                        "        }\n" +
+                        "\n" +
+                        "        requestBuilder.setHeader(\"content-type\", \"application/json\");\n" +
+                        "        requestBuilder.setHeader(\"ce-specversion\", \"1.0\");\n" +
+                        "        requestBuilder.setHeader(\"ce-source\", payload.getSource());\n" +
+                        "        requestBuilder.setHeader(\"ce-type\", \"io.triggermesh.dataweave.transform\");\n" +
+                        "        requestBuilder.setHeader(\"ce-id\", payload.getId());\n" +
+                        "\n" +
+                        "        HttpRequest request = requestBuilder.POST(HttpRequest.BodyPublishers.ofString(body)).build();\n" +
+                        "\n" +
+                        "        try {\n" +
+                        "            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());\n" +
+                        "            // TODO: verify the response status and body\n" +
+                        "            return response.body();\n" +
+                        "        } catch (Exception e) {\n" +
+                        "            System.out.println(\"Error sending event: \" + e.toString());\n" +
+                        "            return null;\n" +
+                        "        }\n" +
+                        "    }\n" +
+                        "}\n");
     }
 
     @Test
@@ -339,5 +464,55 @@ public class MuleToJavaDSLDwlTransformTest extends JavaDSLActionBaseTest {
         assertThat(projectContext.getProjectJavaSources().list().get(0).getTypes().get(0).toString()).isEqualTo("com.example.javadsl.FlowConfigurations");
         assertThat(projectContext.getProjectJavaSources().list().get(1).getTypes().get(0).toString()).isEqualTo("com.example.javadsl.MultipleTransformsTransform_2");
         assertThat(projectContext.getProjectJavaSources().list().get(2).getTypes().get(0).toString()).isEqualTo("com.example.javadsl.MultipleTransformsTransform_0");
+    }
+
+    @Test
+    public void multipleDWLTransformInSameFlowShouldProduceMultipleClassesWithTriggerMeshEnabled() {
+        enableTriggerMeshTransform();
+
+        final String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>    " +
+                "<mule xmlns:dw=\"http://www.mulesoft.org/schema/mule/ee/dw\" xmlns=\"http://www.mulesoft.org/schema/mule/core\" xmlns:doc=\"http://www.mulesoft.org/schema/mule/documentation\"    " +
+                "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"    " +
+                "    xsi:schemaLocation=\"http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd    " +
+                "http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd    " +
+                "http://www.mulesoft.org/schema/mule/db http://www.mulesoft.org/schema/mule/db/current/mule-db.xsd    " +
+                "http://www.mulesoft.org/schema/mule/ee/dw http://www.mulesoft.org/schema/mule/ee/dw/current/dw.xsd\">    " +
+                "    <flow name=\"multipleTransforms\">    " +
+                "        <dw:transform-message doc:name=\"Transform Message\">    " +
+                "            <dw:set-payload><![CDATA[%dw 1.0    " +
+                "%output application/json indent = true, skipNullOn = \"everywhere\"    " +
+                "---    " +
+                "{    " +
+                "    \"hello\": {    " +
+                "        \"world\": {    " +
+                "            \"hello\": \"indeed!\",    " +
+                "        },    " +
+                "    }    " +
+                "}]]></dw:set-payload>    " +
+                "        </dw:transform-message>    " +
+                "        <logger />    " +
+                "        <dw:transform-message doc:name=\"Build Response Message\">    " +
+                "            <dw:set-payload><![CDATA[%dw 1.0    " +
+                "%output application/json indent = true, skipNullOn = \"everywhere\"    " +
+                "---    " +
+                "{    " +
+                "    \"responseBody\": {    " +
+                "        \"responseInfo\": {    " +
+                "            \"responseStatus\": \"200\"    " +
+                "        },    " +
+                "    }    " +
+                "}]]></dw:set-payload>    " +
+                "        </dw:transform-message>    " +
+                "    </flow>    " +
+                "</mule>";
+
+        addXMLFileToResource(xml);
+        runAction();
+
+        assertThat(projectContext.getProjectJavaSources().list()).hasSize(4);
+        assertThat(projectContext.getProjectJavaSources().list().get(0).getTypes().get(0).toString()).isEqualTo("com.example.javadsl.FlowConfigurations");
+        assertThat(projectContext.getProjectJavaSources().list().get(1).getTypes().get(0).toString()).isEqualTo("com.example.javadsl.TmDwPayload");
+        assertThat(projectContext.getProjectJavaSources().list().get(2).getTypes().get(0).toString()).isEqualTo("com.example.javadsl.MultipleTransformsTransformTM_2");
+        assertThat(projectContext.getProjectJavaSources().list().get(3).getTypes().get(0).toString()).isEqualTo("com.example.javadsl.MultipleTransformsTransformTM_0");
     }
 }


### PR DESCRIPTION
I introduced a new runtime flag for spring-boot-migrator called `sbm.muleTriggerMeshTransformEnabled` that will modify the generated mule-to-boot recipe for handling DataWeave transformations to stream the transformation to [TriggerMesh's Dataweave Transformer](https://docs.triggermesh.io/guides/dataweavetransformation/).

The generated code works best when the service runs inside a Kubernetes cluster leveraging Knative's Sink Binding to associate the the newly migrated service to the TriggerMesh Dataweave transformation, however the service can run on it's own by setting the `K_SINK` environment variable to the exposed transformation service.

I created a [gist](https://gist.github.com/cab105/446c07cc54c646913dca459d2ddd9a9f) to demonstrate what an integration within TriggerMesh would look like.