### PR TITLE
Fixing ehcache issue found at spring-pet-clinic project #294

### DIFF
--- a/applications/spring-shell/src/test/java/org/springframework/sbm/BootUpgrade_27_30_IntegrationTest.java
+++ b/applications/spring-shell/src/test/java/org/springframework/sbm/BootUpgrade_27_30_IntegrationTest.java
@@ -19,9 +19,13 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.maven.MavenParser;
+import org.openrewrite.maven.tree.Dependency;
+import org.openrewrite.maven.tree.MavenResolutionResult;
 import org.openrewrite.xml.tree.Xml;
 
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
@@ -48,6 +52,33 @@ public class BootUpgrade_27_30_IntegrationTest extends IntegrationTestBaseClass 
         verifyConstructorBindingRemoval();
         verifyCrudRepoAddition();
         verifyAutoConfigurationIsRefactored();
+        verifyEhCacheVersionIsUpgraded();
+    }
+
+    private void verifyEhCacheVersionIsUpgraded() {
+        String pomContent = loadFile(Path.of("pom.xml"));
+
+        Xml.Document mavenAsXMLDocument = parsePom(pomContent);
+
+        List<Dependency> dependencies = mavenAsXMLDocument
+                .getMarkers()
+                .findFirst(MavenResolutionResult.class)
+                .get()
+                .getPom()
+                .getRequestedDependencies();
+
+        Optional<Dependency> ehcacheResult = dependencies
+                .stream()
+                .filter(dependency -> dependency.getArtifactId().equals("ehcache"))
+                .findFirst();
+
+        assertThat(ehcacheResult).isPresent();
+
+        Dependency ehcacheDependency = ehcacheResult.get();
+
+        assertThat(ehcacheDependency.getArtifactId()).isEqualTo("ehcache");
+        assertThat(ehcacheDependency.getGav().getGroupId()).isEqualTo("org.ehcache");
+        assertThat(ehcacheDependency.getGav().getVersion()).isNull();
     }
 
     private void verifyAutoConfigurationIsRefactored() {

--- a/applications/spring-shell/src/test/java/org/springframework/sbm/BootUpgrade_27_30_IntegrationTest.java
+++ b/applications/spring-shell/src/test/java/org/springframework/sbm/BootUpgrade_27_30_IntegrationTest.java
@@ -79,6 +79,7 @@ public class BootUpgrade_27_30_IntegrationTest extends IntegrationTestBaseClass 
         assertThat(ehcacheDependency.getArtifactId()).isEqualTo("ehcache");
         assertThat(ehcacheDependency.getGav().getGroupId()).isEqualTo("org.ehcache");
         assertThat(ehcacheDependency.getGav().getVersion()).isNull();
+        assertThat(ehcacheDependency.getClassifier()).isEqualTo("jakarta");
     }
 
     private void verifyAutoConfigurationIsRefactored() {

--- a/applications/spring-shell/src/test/resources/testcode/boot-migration-27-30/README.md
+++ b/applications/spring-shell/src/test/resources/testcode/boot-migration-27-30/README.md
@@ -1,10 +1,8 @@
-TODO: 
-fill this file
+**Features used in the current project**
 
+* ehcache in pom is mentioned this helps validate our migration to spring 3 where ehcache classifier has to be used to resolve version.
+* Uses Constructor binding on classes which will be removed when migrating to Spring 3
+* Uses PagingAndSortingRepo interface where CrudRepo has been removed.
+* Uses properties that will be removed/moved on spring 3 migration
+* Uses micrometer packages which are moved to a new structure.
 
-What features this project has that we are testing
-
-* It has ehcahce to make sure unknown dependencies get migrated
-* Constructor binding
-* Crud repo
-* property migration

--- a/applications/spring-shell/src/test/resources/testcode/boot-migration-27-30/README.md
+++ b/applications/spring-shell/src/test/resources/testcode/boot-migration-27-30/README.md
@@ -1,0 +1,10 @@
+TODO: 
+fill this file
+
+
+What features this project has that we are testing
+
+* It has ehcahce to make sure unknown dependencies get migrated
+* Constructor binding
+* Crud repo
+* property migration

--- a/applications/spring-shell/src/test/resources/testcode/boot-migration-27-30/pom.xml
+++ b/applications/spring-shell/src/test/resources/testcode/boot-migration-27-30/pom.xml
@@ -27,6 +27,10 @@
             <artifactId>micrometer-registry-prometheus</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.ehcache</groupId>
+            <artifactId>ehcache</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>

--- a/applications/spring-shell/src/test/resources/testcode/boot-migration-27-30/src/main/java/org/springboot/example/ehcache/EventLogger.java
+++ b/applications/spring-shell/src/test/resources/testcode/boot-migration-27-30/src/main/java/org/springboot/example/ehcache/EventLogger.java
@@ -1,0 +1,11 @@
+package org.springboot.example.ehcache;
+
+import org.ehcache.event.CacheEvent;
+import org.ehcache.event.CacheEventListener;
+
+public class EventLogger implements CacheEventListener<Object, Object> {
+    @Override
+    public void onEvent(CacheEvent<?, ?> cacheEvent) {
+        System.out.println("My ehcache event listener is called");
+    }
+}

--- a/applications/spring-shell/src/test/resources/testcode/boot-migration-27-30/src/main/java/org/springboot/example/upgrade/StudentRepoReactiveSorting.java
+++ b/applications/spring-shell/src/test/resources/testcode/boot-migration-27-30/src/main/java/org/springboot/example/upgrade/StudentRepoReactiveSorting.java
@@ -1,6 +1,5 @@
 package org.springboot.example.upgrade;
 
-import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.data.repository.reactive.ReactiveSortingRepository;
 
 public interface StudentRepoReactiveSorting extends ReactiveSortingRepository<Student, Long> {

--- a/components/sbm-recipes-boot-upgrade/src/main/resources/recipes/boot-2.7-3.0-dependency-version-update.yaml
+++ b/components/sbm-recipes-boot-upgrade/src/main/resources/recipes/boot-2.7-3.0-dependency-version-update.yaml
@@ -40,6 +40,13 @@
         displayName: Upgrade to Spring Data 3.0
         description: 'Upgrade to Spring Data to 3.0 from any prior version.'
         recipeList:
+          - org.openrewrite.maven.ChangeDependencyClassifier:
+              groupId: org.ehcache
+              artifactId: ehcache
+              newClassifier: jakarta              
+          - org.openrewrite.maven.ChangeDependencyVersion:
+              dependencyPattern: org.ehcache:ehcache
+              newVersion: 3.10.0
           - org.openrewrite.maven.UpgradeParentVersion:
               groupId: org.springframework.boot
               artifactId: spring-boot-starter-parent


### PR DESCRIPTION
We have fixed the ehcache issue found at spring-pet-clinic project.

Following steps are taken to fix the issue:
* add ehcache version to 2.7.X spring pom
* add jakarta classifier to 2.7.X spring pom
* then upgrade 2.7.X spring pom to 3.x spring, this upgrade removes explicit version automatically which is redundant

Explicit version and jakarta classifier is needed on 2.7.X to avoid resolution issue from open rewrite.

Closes: [Issue 294](https://github.com/spring-projects-experimental/spring-boot-migrator/issues/294) 