### PR TITLE
Move creation of rewrite recipe from string into RewriteRecipeLoader

### DIFF
--- a/components/sbm-core/src/main/java/org/springframework/sbm/engine/recipe/OpenRewriteNamedRecipeAdapter.java
+++ b/components/sbm-core/src/main/java/org/springframework/sbm/engine/recipe/OpenRewriteNamedRecipeAdapter.java
@@ -39,11 +39,11 @@ public class OpenRewriteNamedRecipeAdapter extends AbstractAction {
 
     @JsonIgnore
     @Autowired
-    private OpenRewriteRecipeRunner openRewriteRecipeRunner;
+    private RewriteRecipeRunner rewriteRecipeRunner;
 
     @Override
     public void apply(ProjectContext context) {
         Recipe recipe = rewriteRecipeLoader.loadRewriteRecipe(openRewriteRecipeName);
-        openRewriteRecipeRunner.run(context, recipe);
+        rewriteRecipeRunner.run(context, recipe);
     }
 }

--- a/components/sbm-core/src/main/java/org/springframework/sbm/engine/recipe/RewriteRecipeRunner.java
+++ b/components/sbm-core/src/main/java/org/springframework/sbm/engine/recipe/RewriteRecipeRunner.java
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 
 @Component
-public class OpenRewriteRecipeRunner {
+public class RewriteRecipeRunner {
     @Autowired
     private RewriteMigrationResultMerger resultMerger;
 

--- a/components/sbm-core/src/test/java/org/springframework/sbm/engine/recipe/OpenRewriteDeclarativeRecipeAdapterIntegrationTest.java
+++ b/components/sbm-core/src/test/java/org/springframework/sbm/engine/recipe/OpenRewriteDeclarativeRecipeAdapterIntegrationTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.sbm.engine.recipe;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.sbm.engine.context.ProjectContext;
+import org.springframework.sbm.project.RewriteSourceFileWrapper;
+import org.springframework.sbm.project.resource.ResourceHelper;
+import org.springframework.sbm.project.resource.TestProjectContext;
+import org.springframework.validation.beanvalidation.CustomValidatorBean;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest(classes = {
+        RecipeParser.class,
+        RewriteRecipeLoader.class,
+        YamlObjectMapperConfiguration.class,
+        CustomValidator.class,
+        ResourceHelper.class,
+        ActionDeserializerRegistry.class,
+        RewriteMigrationResultMerger.class,
+        RewriteRecipeRunner.class,
+        RewriteSourceFileWrapper.class,
+        CustomValidatorBean.class
+})
+class OpenRewriteDeclarativeRecipeAdapterIntegrationTest {
+
+    @Autowired
+    RecipeParser recipeParser;
+
+    @Test
+    void adapterActionShouldExecuteOpenRewriteYamlRecipe() throws IOException {
+        String validSbmRecipeYaml =
+                        "- name: test-recipe\n" +
+                        "  description: Replace deprecated spring.datasource.* properties\n" +
+                        "  condition:\n" +
+                        "    type: org.springframework.sbm.common.migration.conditions.TrueCondition\n" +
+                        "  actions:\n" +
+                        "    - type: org.springframework.sbm.engine.recipe.OpenRewriteDeclarativeRecipeAdapter\n" +
+                        "      description: Call a OpenRewrite recipe\n" +
+                        "      openRewriteRecipe: |-\n" +
+                        "        type: specs.openrewrite.org/v1beta/recipe\n" +
+                        "        name: org.openrewrite.java.RemoveAnnotation\n" +
+                        "        displayName: Order imports\n" +
+                        "        description: Order imports\n" +
+                        "        recipeList:\n" +
+                        "          - org.openrewrite.java.RemoveAnnotation:\n" +
+                        "              annotationPattern: \"@java.lang.Deprecated\"\n" +
+                        "          - org.openrewrite.java.format.AutoFormat";
+
+        // parse the recipe
+        Recipe[] recipes = recipeParser.parseRecipe(validSbmRecipeYaml);
+        assertThat(recipes[0].getActions().get(0)).isInstanceOf(OpenRewriteDeclarativeRecipeAdapter.class);
+        // retrieve adapter action
+        OpenRewriteDeclarativeRecipeAdapter recipeAdapter = (OpenRewriteDeclarativeRecipeAdapter) recipes[0].getActions().get(0);
+        // create a test prokect
+        String javaSource = "@java.lang.Deprecated\n" +
+                "public class Foo {}";
+        ProjectContext context = TestProjectContext.buildProjectContext()
+                .addJavaSource("src/main/java", javaSource)
+                .build();
+        // run the adapter action and thus the declared rewrite recipes
+        recipeAdapter.apply(context);
+        // verify that the rewrite recipes were executed (reformatted, @Deprecated added)
+        assertThat(context.getProjectJavaSources().list().get(0).print()).isEqualTo(
+                "public class Foo {\n" +
+                        "}"
+        );
+    }
+}

--- a/components/sbm-core/src/test/java/org/springframework/sbm/engine/recipe/OpenRewriteDeclarativeRecipeAdapterTest.java
+++ b/components/sbm-core/src/test/java/org/springframework/sbm/engine/recipe/OpenRewriteDeclarativeRecipeAdapterTest.java
@@ -17,110 +17,39 @@
 package org.springframework.sbm.engine.recipe;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.sbm.engine.context.ProjectContext;
-import org.springframework.sbm.project.RewriteSourceFileWrapper;
-import org.springframework.sbm.project.resource.ResourceHelper;
-import org.springframework.sbm.project.resource.TestProjectContext;
-import org.springframework.validation.beanvalidation.CustomValidatorBean;
 
-import java.io.IOException;
+import static org.mockito.Mockito.*;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+@ExtendWith(MockitoExtension.class)
+public class OpenRewriteDeclarativeRecipeAdapterTest {
 
-@SpringBootTest(classes = {
-        RecipeParser.class,
-        YamlObjectMapperConfiguration.class,
-        CustomValidator.class,
-        ResourceHelper.class,
-        ActionDeserializerRegistry.class,
-        RewriteMigrationResultMerger.class,
-        OpenRewriteRecipeRunner.class,
-        RewriteSourceFileWrapper.class,
-        CustomValidatorBean.class
-})
-class OpenRewriteDeclarativeRecipeAdapterTest {
+    @Mock
+    RewriteRecipeLoader rewriteRecipeLoader;
 
-    @Autowired
-    RecipeParser recipeParser;
+    @Mock
+    RewriteRecipeRunner rewriteRecipeRunner;
+
+    @InjectMocks
+    OpenRewriteDeclarativeRecipeAdapter sut;
 
     @Test
-    void recipeFromYaml() throws IOException {
-        String yaml =
-                        "- name: test-recipe\n" +
-                        "  description: Replace deprecated spring.datasource.* properties\n" +
-                        "  condition:\n" +
-                        "    type: org.springframework.sbm.common.migration.conditions.TrueCondition\n" +
-                        "  actions:\n" +
-                        "    - type: org.springframework.sbm.engine.recipe.OpenRewriteDeclarativeRecipeAdapter\n" +
-                        "      description: Call a OpenRewrite recipe\n" +
-                        "      openRewriteRecipe: |-\n" +
-                        "        type: specs.openrewrite.org/v1beta/recipe\n" +
-                        "        name: org.openrewrite.java.RemoveAnnotation\n" +
-                        "        displayName: Order imports\n" +
-                        "        description: Order imports\n" +
-                        "        recipeList:\n" +
-                        "          - org.openrewrite.java.RemoveAnnotation:\n" +
-                        "              annotationPattern: \"@java.lang.Deprecated\"\n" +
-                        "          - org.openrewrite.java.format.AutoFormat";
+    void testApply() {
+        String recipeDeclaration = "name: some-recipe";
+        sut.setOpenRewriteRecipe(recipeDeclaration);
 
-        Recipe[] recipes = recipeParser.parseRecipe(yaml);
-        assertThat(recipes[0].getActions().get(0)).isInstanceOf(OpenRewriteDeclarativeRecipeAdapter.class);
-        OpenRewriteDeclarativeRecipeAdapter recipeAdapter = (OpenRewriteDeclarativeRecipeAdapter) recipes[0].getActions().get(0);
+        org.openrewrite.Recipe recipe = mock(org.openrewrite.Recipe.class);
+        when(rewriteRecipeLoader.createRecipe(recipeDeclaration)).thenReturn(recipe);
+        ProjectContext context = mock(ProjectContext.class);
 
-        String javaSource = "@java.lang.Deprecated\n" +
-                "public class Foo {}";
+        sut.apply(context);
 
-        ProjectContext context = TestProjectContext.buildProjectContext()
-                .addJavaSource("src/main/java", javaSource)
-                .build();
-
-        recipeAdapter.apply(context);
-
-        assertThat(context.getProjectJavaSources().list().get(0).print()).isEqualTo(
-                "public class Foo {\n" +
-                        "}"
-        );
+        verify(rewriteRecipeRunner).run(context, recipe);
     }
 
-    @Test
-    public void propagateExceptionFromOpenRewriteRecipe() throws IOException {
 
-        String actionDescription =
-                "- name: test-recipe\n" +
-                        "  description: Replace deprecated spring.datasource.* properties\n" +
-                        "  condition:\n" +
-                        "    type: org.springframework.sbm.common.migration.conditions.TrueCondition\n" +
-                        "  actions:\n" +
-                        "    - type: org.springframework.sbm.engine.recipe.OpenRewriteDeclarativeRecipeAdapter\n" +
-                        "      condition:\n" +
-                        "        type: org.springframework.sbm.common.migration.conditions.TrueCondition\n" +
-                        "        versionStartingWith: \"2.7.\"\n" +
-                        "      description: Add Spring Milestone Repository and bump parent pom to 3.0.0-M3\n" +
-                        "\n" +
-                        "      openRewriteRecipe: |-\n" +
-                        "        type: specs.openrewrite.org/v1beta/recipe\n" +
-                        "        name: org.openrewrite.java.spring.boot3.data.UpgradeSpringData30\n" +
-                        "        displayName: Upgrade to Spring Data 3.0\n" +
-                        "        description: 'Upgrade to Spring Data to 3.0 from any prior version.'\n" +
-                        "        recipeList:\n" +
-                        "          - org.springframework.sbm.engine.recipe.ErrorClass\n";
-
-        Recipe[] recipes = recipeParser.parseRecipe(actionDescription);
-        assertThat(recipes[0].getActions().get(0)).isInstanceOf(OpenRewriteDeclarativeRecipeAdapter.class);
-        OpenRewriteDeclarativeRecipeAdapter recipeAdapter = (OpenRewriteDeclarativeRecipeAdapter) recipes[0].getActions().get(0);
-
-        String javaSource = "@java.lang.Deprecated\n" +
-                "public class Foo {}";
-
-        ProjectContext context = TestProjectContext.buildProjectContext()
-                .addJavaSource("src/main/java", javaSource)
-                .build();
-
-        RuntimeException thrown = assertThrows(RuntimeException.class, () -> recipeAdapter.apply(context));
-
-        assertThat(thrown).hasRootCauseMessage("A problem happened whilst visiting");
-    }
 }

--- a/components/sbm-core/src/test/java/org/springframework/sbm/engine/recipe/OpenRewriteNamedRecipeAdapterIntegrationTest.java
+++ b/components/sbm-core/src/test/java/org/springframework/sbm/engine/recipe/OpenRewriteNamedRecipeAdapterIntegrationTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.sbm.engine.recipe;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.sbm.engine.context.ProjectContext;
+import org.springframework.sbm.project.RewriteSourceFileWrapper;
+import org.springframework.sbm.project.resource.ResourceHelper;
+import org.springframework.sbm.project.resource.TestProjectContext;
+import org.springframework.validation.beanvalidation.CustomValidatorBean;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest(classes = {
+        RecipeParser.class,
+        YamlObjectMapperConfiguration.class,
+        CustomValidator.class,
+        ResourceHelper.class,
+        ActionDeserializerRegistry.class,
+        RewriteMigrationResultMerger.class,
+        RewriteRecipeRunner.class,
+        RewriteSourceFileWrapper.class,
+        RewriteRecipeLoader.class,
+        CustomValidatorBean.class
+})
+public class OpenRewriteNamedRecipeAdapterIntegrationTest {
+
+    @Autowired
+    RecipeParser recipeParser;
+
+    @Test
+    void recipeFromYaml() throws IOException {
+        String yaml =
+                "- name: test-recipe\n" +
+                "  description: Replace deprecated spring.datasource.* properties\n" +
+                "  condition:\n" +
+                "    type: org.springframework.sbm.common.migration.conditions.TrueCondition\n" +
+                "  actions:\n" +
+                "    - type: org.springframework.sbm.engine.recipe.OpenRewriteNamedRecipeAdapter\n" +
+                "      description: Call a OpenRewrite recipe\n" +
+                "      openRewriteRecipeName: org.springframework.sbm.dummy.RemoveDeprecatedAnnotation\n";
+
+        // parse the recipe
+        Recipe[] recipes = recipeParser.parseRecipe(yaml);
+        assertThat(recipes[0].getActions().get(0)).isInstanceOf(OpenRewriteNamedRecipeAdapter.class);
+        // retrieve adapter action
+        OpenRewriteNamedRecipeAdapter recipeAdapter = (OpenRewriteNamedRecipeAdapter) recipes[0].getActions().get(0);
+        // create context
+        String javaSource = "@java.lang.Deprecated\n" +
+                "public class Foo {\n" +
+                "}\n";
+
+        ProjectContext context = TestProjectContext.buildProjectContext()
+                .addJavaSource("src/main/java", javaSource)
+                .build();
+        // and apply the adapter
+        recipeAdapter.apply(context);
+        // verify the openrewrite recipe ran
+        assertThat(context.getProjectJavaSources().list().get(0).print()).isEqualTo(
+                "public class Foo {\n" +
+                        "}\n"
+        );
+    }
+
+    @Test
+    public void propagateExceptionFromOpenRewriteRecipe() throws IOException {
+
+        String actionDescription =
+                "- name: test-recipe\n" +
+                        "  description: Replace deprecated spring.datasource.* properties\n" +
+                        "  condition:\n" +
+                        "    type: org.springframework.sbm.common.migration.conditions.TrueCondition\n" +
+                        "  actions:\n" +
+                        "    - type: org.springframework.sbm.engine.recipe.OpenRewriteNamedRecipeAdapter\n" +
+                        "      description: Test recipe producing exception\n" +
+                        "      openRewriteRecipeName: org.springframework.sbm.engine.recipe.ErrorClass\n";
+
+        Recipe[] recipes = recipeParser.parseRecipe(actionDescription);
+        assertThat(recipes[0].getActions().get(0)).isInstanceOf(OpenRewriteNamedRecipeAdapter.class);
+        OpenRewriteNamedRecipeAdapter recipeAdapter = (OpenRewriteNamedRecipeAdapter) recipes[0].getActions().get(0);
+
+        String javaSource = "@java.lang.Deprecated\n" +
+                "public class Foo {}";
+
+        ProjectContext context = TestProjectContext.buildProjectContext()
+                .addJavaSource("src/main/java", javaSource)
+                .build();
+
+        RuntimeException thrown = assertThrows(RuntimeException.class, () -> recipeAdapter.apply(context));
+
+        assertThat(thrown).hasRootCauseMessage("A problem happened whilst visiting");
+    }
+}

--- a/components/sbm-core/src/test/java/org/springframework/sbm/engine/recipe/OpenRewriteNamedRecipeAdapterTest.java
+++ b/components/sbm-core/src/test/java/org/springframework/sbm/engine/recipe/OpenRewriteNamedRecipeAdapterTest.java
@@ -17,6 +17,10 @@
 package org.springframework.sbm.engine.recipe;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.sbm.engine.context.ProjectContext;
@@ -29,82 +33,31 @@ import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
 
-@SpringBootTest(classes = {
-        RecipeParser.class,
-        YamlObjectMapperConfiguration.class,
-        CustomValidator.class,
-        ResourceHelper.class,
-        ActionDeserializerRegistry.class,
-        RewriteMigrationResultMerger.class,
-        OpenRewriteRecipeRunner.class,
-        RewriteSourceFileWrapper.class,
-        RewriteRecipeLoader.class,
-        CustomValidatorBean.class
-})
+@ExtendWith(MockitoExtension.class)
 public class OpenRewriteNamedRecipeAdapterTest {
+    @Mock
+    RewriteRecipeLoader rewriteRecipeLoader;
 
-    @Autowired
-    RecipeParser recipeParser;
+    @Mock
+    RewriteRecipeRunner rewriteRecipeRunner;
 
-    @Test
-    void recipeFromYaml() throws IOException {
-        String yaml =
-                "- name: test-recipe\n" +
-                "  description: Replace deprecated spring.datasource.* properties\n" +
-                "  condition:\n" +
-                "    type: org.springframework.sbm.common.migration.conditions.TrueCondition\n" +
-                "  actions:\n" +
-                "    - type: org.springframework.sbm.engine.recipe.OpenRewriteNamedRecipeAdapter\n" +
-                "      description: Call a OpenRewrite recipe\n" +
-                "      openRewriteRecipeName: org.springframework.sbm.dummy.RemoveDeprecatedAnnotation\n";
-
-        Recipe[] recipes = recipeParser.parseRecipe(yaml);
-        assertThat(recipes[0].getActions().get(0)).isInstanceOf(OpenRewriteNamedRecipeAdapter.class);
-        OpenRewriteNamedRecipeAdapter recipeAdapter = (OpenRewriteNamedRecipeAdapter) recipes[0].getActions().get(0);
-
-        String javaSource = "@java.lang.Deprecated\n" +
-                "public class Foo {\n" +
-                "}\n";
-
-        ProjectContext context = TestProjectContext.buildProjectContext()
-                .addJavaSource("src/main/java", javaSource)
-                .build();
-
-        recipeAdapter.apply(context);
-
-        assertThat(context.getProjectJavaSources().list().get(0).print()).isEqualTo(
-                "public class Foo {\n" +
-                        "}\n"
-        );
-    }
+    @InjectMocks
+    OpenRewriteNamedRecipeAdapter sut;
 
     @Test
-    public void propagateExceptionFromOpenRewriteRecipe() throws IOException {
+    void testApply() {
+        String recipeName = "name";
+        sut.setOpenRewriteRecipeName(recipeName);
 
-        String actionDescription =
-                "- name: test-recipe\n" +
-                        "  description: Replace deprecated spring.datasource.* properties\n" +
-                        "  condition:\n" +
-                        "    type: org.springframework.sbm.common.migration.conditions.TrueCondition\n" +
-                        "  actions:\n" +
-                        "    - type: org.springframework.sbm.engine.recipe.OpenRewriteNamedRecipeAdapter\n" +
-                        "      description: Test recipe producing exception\n" +
-                        "      openRewriteRecipeName: org.springframework.sbm.engine.recipe.ErrorClass\n";
+        org.openrewrite.Recipe recipe = mock(org.openrewrite.Recipe.class);
+        when(rewriteRecipeLoader.loadRewriteRecipe(recipeName)).thenReturn(recipe);
+        ProjectContext context = mock(ProjectContext.class);
 
-        Recipe[] recipes = recipeParser.parseRecipe(actionDescription);
-        assertThat(recipes[0].getActions().get(0)).isInstanceOf(OpenRewriteNamedRecipeAdapter.class);
-        OpenRewriteNamedRecipeAdapter recipeAdapter = (OpenRewriteNamedRecipeAdapter) recipes[0].getActions().get(0);
+        sut.apply(context);
 
-        String javaSource = "@java.lang.Deprecated\n" +
-                "public class Foo {}";
-
-        ProjectContext context = TestProjectContext.buildProjectContext()
-                .addJavaSource("src/main/java", javaSource)
-                .build();
-
-        RuntimeException thrown = assertThrows(RuntimeException.class, () -> recipeAdapter.apply(context));
-
-        assertThat(thrown).hasRootCauseMessage("A problem happened whilst visiting");
+        verify(rewriteRecipeRunner).run(context, recipe);
     }
+
 }

--- a/components/sbm-core/src/test/java/org/springframework/sbm/engine/recipe/RewriteRecipeLoaderTest.java
+++ b/components/sbm-core/src/test/java/org/springframework/sbm/engine/recipe/RewriteRecipeLoaderTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.sbm.engine.recipe;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Recipe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class RewriteRecipeLoaderTest {
+
+    @Test
+    void shouldCreateRecipeFromValidYaml() {
+        String rewriteRecipeDeclaration =
+                """
+                type: specs.openrewrite.org/v1beta/recipe
+                name: org.openrewrite.java.spring.boot3.data.UpgradeSpringData30
+                displayName: Upgrade to Spring Data 3.0
+                description: 'Upgrade to Spring Data to 3.0 from any prior version.'
+                recipeList:
+                  - org.springframework.sbm.engine.recipe.ErrorClass
+                """;
+
+        RewriteRecipeLoader sut = new RewriteRecipeLoader();
+
+        Recipe recipe = sut.createRecipe(rewriteRecipeDeclaration);
+        assertThat(recipe.getDescription()).isEqualTo("Upgrade to Spring Data to 3.0 from any prior version.");
+        assertThat(recipe.getDisplayName()).isEqualTo("Upgrade to Spring Data 3.0");
+        assertThat(recipe.getName()).isEqualTo("org.openrewrite.java.spring.boot3.data.UpgradeSpringData30");
+        assertThat(recipe.getRecipeList()).hasSize(1);
+        assertThat(recipe.getRecipeList().get(0).getName()).isEqualTo("org.springframework.sbm.engine.recipe.ErrorClass");
+    }
+
+}


### PR DESCRIPTION
- OpenRewriteDeclarativeRecipeAdapter uses RewriteRecipeLoader to be close to OpenRewriteNamedRecipeAdapter
- RewriteRecipeLoader offers method to create rewrite Recipe from String
- Adds tests
- Add comments
- Remove integration test covered by unittest