### PR TITLE
Resolve hang in failure scenario

### DIFF
--- a/applications/spring-shell/src/main/java/org/springframework/sbm/shell/renderer/RecipeProgressRenderer.java
+++ b/applications/spring-shell/src/main/java/org/springframework/sbm/shell/renderer/RecipeProgressRenderer.java
@@ -122,7 +122,7 @@ public class RecipeProgressRenderer {
 
 
     public synchronized void failProcess() {
-        while (!stepsDeque.isEmpty()) {
+        if (!stepsDeque.isEmpty()) {
             if (stepsDeque.peek().getClass().isAssignableFrom(ProcessStep.class)) {
                 String fail = ((ProcessStep) stepsDeque.pop()).fail();
                 printer.printAndNewLine(fail);


### PR DESCRIPTION
Experienced a hang while attempting to use the spring-boot-migrator to convert a Mule project to Spring Boot.  Tracing the hang resulted in a failure occurring within the program itself, and rather than indicating the failure, spring-boot-migrator locked itself into an infinite loop where issuing a SIGINT from the console wasn't enough.

This fix converts the while check to an if check to ensure that the failure message gets printed, and the program can return a prompt.