### PR TITLE
Add Mule package type to getTopmostApplicationModules

### DIFF
--- a/components/sbm-core/src/main/java/org/springframework/sbm/build/api/ApplicationModules.java
+++ b/components/sbm-core/src/main/java/org/springframework/sbm/build/api/ApplicationModules.java
@@ -112,8 +112,8 @@ public class ApplicationModules {
     public List<Module> getTopmostApplicationModules() {
         List<Module> topmostModules = new ArrayList<>();
         modules.forEach(module -> {
-            // is jar
-            if ("jar".equals(module.getBuildFile().getPackaging())) { // FIXME: other types could be topmost too, e.g. 'war'
+            // is jar or mule-application? (mulesoft apps don't get switched over to JARs until after the recipe runs)
+            if ("jar".equals(module.getBuildFile().getPackaging()) || "mule-application".equals(module.getBuildFile().getPackaging())) { // FIXME: other types could be topmost too, e.g. 'war'
                 // no other pom depends on this pom in its dependency section
                 if (noOtherPomDependsOn(module.getBuildFile())) {
                     // has no parent or parent has packaging pom


### PR DESCRIPTION
Following up on https://github.com/spring-projects-experimental/spring-boot-migrator/pull/373, I was able to figure out why my Mule project was not being picked up by Spring Boot Migrator.  Turns out there's a check in the dependent call of `getTopmostApplicationModules` that whitelists only `jar` based applications. However, Mulesoft projects built with Anypoint Studio defaults to using `mule-application`.  Since this is the package type that I've been using for my mule migration projects, the code has consistently failed.

This PR will whitelist this application type as the `migrate-mule-to-boot` recipe will convert the application type to `jar` after it runs.