### PR TITLE
386 provide api for restcontroller spring beans

### DIFF
--- a/components/sbm-core/src/main/java/org/springframework/sbm/java/impl/OpenRewriteAnnotation.java
+++ b/components/sbm-core/src/main/java/org/springframework/sbm/java/impl/OpenRewriteAnnotation.java
@@ -73,8 +73,8 @@ public class OpenRewriteAnnotation implements Annotation {
     }
 
     @Override
-    public boolean hasAttribute(String timeout) {
-        return false;
+    public boolean hasAttribute(String attribute) {
+        return getAttributes().containsKey(attribute);
     }
 
     @Override

--- a/components/sbm-core/src/test/java/org/springframework/sbm/engine/precondition/PreconditionVerifierIntegrationTest.java
+++ b/components/sbm-core/src/test/java/org/springframework/sbm/engine/precondition/PreconditionVerifierIntegrationTest.java
@@ -36,6 +36,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -131,7 +132,8 @@ public class PreconditionVerifierIntegrationTest {
         assertThat(preconditionVerificationResult.getResults().get(0).getState()).isEqualTo(PreconditionCheck.ResultState.PASSED);
         assertThat(preconditionVerificationResult.getResults().get(0).getMessage()).isEqualTo("Found pom.xml.");
         assertThat(preconditionVerificationResult.getResults().get(1).getState()).isEqualTo(PreconditionCheck.ResultState.PASSED);
-        assertThat(preconditionVerificationResult.getResults().get(1).getMessage()).isEqualTo("'sbm.gitSupportEnabled' is 'true', changes will be committed to branch [master] after each recipe.");
+
+        assertThat(preconditionVerificationResult.getResults().get(1).getMessage()).matches("'sbm\\.gitSupportEnabled' is 'true', changes will be committed to branch \\[(master|main)\\] after each recipe\\.");
         assertThat(preconditionVerificationResult.getResults().get(2).getState()).isEqualTo(PreconditionCheck.ResultState.PASSED);
         assertThat(preconditionVerificationResult.getResults().get(2).getMessage()).isEqualTo("Found required source dir 'src/main/java'.");
         assertThat(preconditionVerificationResult.getResults().get(3).getState()).isEqualTo(PreconditionCheck.ResultState.PASSED);

--- a/components/sbm-recipes-spring-cloud/pom.xml
+++ b/components/sbm-recipes-spring-cloud/pom.xml
@@ -47,6 +47,14 @@
             <artifactId>spring-boot-starter-test</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>ST4</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.sbm</groupId>
             <artifactId>recipe-test-support</artifactId>
             <scope>test</scope>

--- a/components/sbm-support-boot/pom.xml
+++ b/components/sbm-support-boot/pom.xml
@@ -55,6 +55,10 @@
             <artifactId>spring-boot-starter-freemarker</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
         </dependency>

--- a/components/sbm-support-boot/src/main/java/org/springframework/sbm/boot/web/api/RestControllerBean.java
+++ b/components/sbm-support-boot/src/main/java/org/springframework/sbm/boot/web/api/RestControllerBean.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.sbm.boot.web.api;
+
+import org.springframework.sbm.java.api.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Provides an API for classes annotated with {@code RestController}.
+ *
+ * @author  Fabian Krüger
+ */
+public record RestControllerBean(JavaSource js, Type restControllerType) {
+    private static final RestMethodMapper restMethodMapper = new RestMethodMapper();
+    public static final List<String> SPRING_REST_METHOD_ANNOTATIONS = SpringRestMethodAnnotation
+            .getAll()
+            .stream()
+            .map(SpringRestMethodAnnotation::getFullyQualifiedName)
+            .toList();
+
+    /**
+     * Return the list of methods annotated with any of the Spring Boot request mapping annotations like
+     * {@code @RequestMapping} or {@code @GetMapping}.
+     */
+    public List<RestMethod> getRestMethods() {
+        return this.restControllerType.getMethods().stream()
+                .filter(this::isRestMethod)
+                .map(Method.class::cast)
+                .map(restMethodMapper::map)
+                .collect(Collectors.toList());
+    }
+
+    private boolean isRestMethod(Method method) {
+        return method.getAnnotations().stream()
+                .anyMatch(methodAnnotation -> SPRING_REST_METHOD_ANNOTATIONS.contains(methodAnnotation.getFullyQualifiedName()));
+    }
+
+}

--- a/components/sbm-support-boot/src/main/java/org/springframework/sbm/boot/web/api/RestMethod.java
+++ b/components/sbm-support-boot/src/main/java/org/springframework/sbm/boot/web/api/RestMethod.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.sbm.boot.web.api;
+
+import lombok.Builder;
+import org.springframework.sbm.java.api.Method;
+import org.springframework.sbm.java.api.MethodParam;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Record of request mapping annotation data (e.g. {@code RequestMapping} or {@code GetMapping}).
+ *
+ * @param path the list of mapped paths
+ * @param name
+ * @param method
+ * @param params
+ * @param headers the list of headers
+ * @param consumes the effective media types
+ * @param produces the effective media types
+ * @param methodReference the method
+ * @param returnType the fully qualified of the return type
+ * @param requestBodyParameterType the fully qualified name of parameter annotated with {@RequestBody}
+ *
+ * @author Fabian Krüger
+ */
+@Builder
+public record RestMethod(
+        List<String> path,
+        String name,
+        List<RequestMethod> method,
+        List<String> params,
+        List<String> headers,
+        List<String> consumes,
+        List<String> produces,
+        Method methodReference,
+        String returnType,
+        Optional<MethodParam> requestBodyParameterType) {
+
+    public Optional<MethodParam> requestBodyParameterType() {
+        if(requestBodyParameterType == null) return Optional.empty();
+        return requestBodyParameterType;
+    }
+}

--- a/components/sbm-support-boot/src/main/java/org/springframework/sbm/boot/web/api/RestMethodMapper.java
+++ b/components/sbm-support-boot/src/main/java/org/springframework/sbm/boot/web/api/RestMethodMapper.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.sbm.boot.web.api;
+
+import org.jetbrains.annotations.NotNull;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.springframework.http.MediaType;
+import org.springframework.sbm.java.api.Annotation;
+import org.springframework.sbm.java.api.Expression;
+import org.springframework.sbm.java.api.Method;
+import org.springframework.sbm.java.impl.OpenRewriteExpression;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static java.util.function.Predicate.not;
+import static org.springframework.sbm.boot.web.api.SpringRestMethodAnnotation.*;
+
+class RestMethodMapper {
+
+    public static final List<String> SPRING_REST_METHOD_ANNOTATIONS = SpringRestMethodAnnotation.getAll().stream().map(SpringRestMethodAnnotation::getFullyQualifiedName)
+            .collect(Collectors.toList());
+
+    public RestMethod map(Method method) {
+        return mapToRestMethod(method);
+    }
+
+    private RestMethod mapToRestMethod(Method method) {
+        RestMethod.RestMethodBuilder builder = RestMethod.builder();
+        Annotation annotation = getRestMethodAnnotation(method);
+        builder.methodReference(method);
+        buildRestMethod(method, annotation, builder);
+        buildRequestBodyType(method, builder);
+        return builder.build();
+    }
+
+    private void buildRequestBodyType(Method method, RestMethod.RestMethodBuilder builder) {
+        builder.requestBodyParameterType(method.getParams().stream()
+                                                 .filter(p -> p.containsAnnotation(Pattern.compile(".*\\.RequestBody")))
+                                                 .findFirst());
+    }
+
+    private Annotation getRestMethodAnnotation(Method method) {
+        return method.getAnnotations().stream()
+                .filter(methodAnnotations -> SPRING_REST_METHOD_ANNOTATIONS.stream().anyMatch(fqName -> methodAnnotations.getFullyQualifiedName().equals(fqName)))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException(String.format("The provided method '%s' has no Spring Request Mapping annpotation.", method.getName())));
+    }
+
+    private void buildRestMethod(Method method, Annotation annotation, RestMethod.RestMethodBuilder builder) {
+        String name = "name";
+        if(annotation.hasAttribute(name)) {
+            mapNameAttribute(annotation, builder, name);
+        }
+        extractExistingAnnotationAttribute(annotation, "value", values -> builder.path(values));
+        extractExistingAnnotationAttribute(annotation, "path", paths -> builder.path(paths));
+        extractExistingAnnotationAttribute(annotation, "params", params -> builder.params(params));
+        extractExistingAnnotationAttribute(annotation, "consumes", consumes -> builder.consumes(consumes));
+        extractExistingAnnotationAttribute(annotation, "produces", produces -> builder.produces(produces));
+        extractExistingAnnotationAttribute(annotation, "headers", headers -> builder.headers(headers));
+        mapMethodAttribute(annotation, builder);
+
+        if(!annotation.hasAttribute("consumes")) {
+            builder.consumes(List.of(MediaType.APPLICATION_JSON_VALUE));
+        }
+        if(!annotation.hasAttribute("produces")) {
+            builder.produces(List.of(MediaType.APPLICATION_JSON_VALUE));
+        }
+
+        String fullyQualifiedReturnType = ((JavaType.Class) method
+                .getMethodDecl()
+                .getReturnTypeExpression()
+                .getType()).getFullyQualifiedName();
+
+        builder.returnType(fullyQualifiedReturnType);
+    }
+
+    private void extractExistingAnnotationAttribute(Annotation annotation, String attribute, Consumer<List<String>> valueConsumer) {
+        if(annotation.hasAttribute(attribute)) {
+            extractAnnotationAttribute(annotation, attribute, valueConsumer);
+        }
+    }
+
+    private void extractAnnotationAttribute(Annotation annotation, String attribute, Consumer<List<String>> consumer) {
+        Expression expression = annotation.getAttributes().get(attribute);
+        List<String> values = handleExpression(expression);
+        consumer.accept(values);
+    }
+
+    private void mapNameAttribute(Annotation annotation, RestMethod.RestMethodBuilder builder, String name) {
+        Expression value = annotation.getAttributes().get(name);
+        String s = value.getAssignmentRightSide().printVariable();
+        builder.name(s);
+    }
+
+    private void mapMethodAttribute(Annotation annotation, RestMethod.RestMethodBuilder builder) {
+        if(annotation.hasAttribute("method")) {
+            List<String> methods = handleExpression(annotation.getAttribute("method"));
+            builder.method(methods.stream().map(m -> RequestMethod.valueOf(m)).collect(Collectors.toList()));
+        }
+        findAndMapMethodAttribute(annotation, builder, GET_MAPPING.getFullyQualifiedName(), RequestMethod.GET);
+        findAndMapMethodAttribute(annotation, builder, POST_MAPPING.getFullyQualifiedName(), RequestMethod.POST);
+        findAndMapMethodAttribute(annotation, builder, PUT_MAPPING.getFullyQualifiedName(), RequestMethod.PUT);
+        findAndMapMethodAttribute(annotation, builder, DELETE_MAPPING.getFullyQualifiedName(), RequestMethod.DELETE);
+        findAndMapMethodAttribute(annotation, builder, PATCH_MAPPING.getFullyQualifiedName(), RequestMethod.PATCH);
+    }
+
+    private void findAndMapMethodAttribute(Annotation annotation, RestMethod.RestMethodBuilder builder, String requestNapping, RequestMethod requestMethod) {
+        if(annotation.getFullyQualifiedName().equals(requestNapping)) {
+            builder.method(List.of(requestMethod));
+        }
+    }
+
+    private List<String> handleLiteral(org.openrewrite.java.tree.Expression wrapped) {
+        J.Literal literal = J.Literal.class.cast(wrapped);
+        return  List.of((String)literal.getValue());
+    }
+
+    @NotNull
+    private List<String> handleArray(org.openrewrite.java.tree.Expression expression) {
+        J.NewArray array = J.NewArray.class.cast(expression);
+        List<String> elements = array
+                .getInitializer()
+                .stream()
+                .map(e -> this.handleExpression(e))
+                .filter(not(List::isEmpty))
+                .map(s -> s.get(0))
+                .collect(Collectors.toList());
+        return elements;
+    }
+
+    private List<String> handleExpression(Expression value) {
+        OpenRewriteExpression openRewriteExpression = OpenRewriteExpression.class.cast(value);
+        org.openrewrite.java.tree.Expression wrapped = openRewriteExpression.getWrapped();
+        return handleExpression(wrapped);
+    }
+
+    private List<String> handleExpression(org.openrewrite.java.tree.Expression expression) {
+        List<String> elements = new ArrayList<>();
+        if(J.Literal.class.isInstance(expression)) {
+            elements = handleLiteral(expression);
+        }
+        else if(J.NewArray.class.isInstance(expression)) {
+            elements = handleArray(expression);
+        }
+        else if(J.Assignment.class.isInstance(expression)) {
+            J.Assignment assignment = J.Assignment.class.cast(expression);
+            org.openrewrite.java.tree.Expression assignment1 = assignment.getAssignment();
+            if(J.NewArray.class.isInstance(assignment1)) {
+                elements = handleArray(assignment1);
+            }
+            else if(J.FieldAccess.class.isInstance(assignment.getAssignment())) {
+                elements = List.of(staticFieldReference(assignment.getAssignment()));
+            }
+        } else if(J.FieldAccess.class.isInstance(expression)) {
+            elements = List.of(staticFieldReference(expression));
+        }
+        return elements;
+    }
+
+    private String staticFieldReference(org.openrewrite.java.tree.Expression expression) {
+        J.FieldAccess fieldAccess = J.FieldAccess.class.cast(expression);
+        String fqName = ((JavaType.Class) fieldAccess.getTarget().getType()).getFullyQualifiedName();
+        Class<?> aClass = null;
+        String methodName = fieldAccess.getName().getSimpleName();
+        try {
+            aClass = Class.forName(fqName);
+            Object o = aClass.getDeclaredField(methodName).get(null);
+            return o.toString();
+        } catch (NoSuchFieldException | ClassNotFoundException | IllegalAccessException e) {
+            throw new RuntimeException(String.format("Exception while attempting to resolve the value for constant '%s.%s'", aClass, methodName));
+        }
+    }
+}

--- a/components/sbm-support-boot/src/main/java/org/springframework/sbm/boot/web/api/SpringRestMethodAnnotation.java
+++ b/components/sbm-support-boot/src/main/java/org/springframework/sbm/boot/web/api/SpringRestMethodAnnotation.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.sbm.boot.web.api;
+
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.List;
+
+enum SpringRestMethodAnnotation {
+    DELETE_MAPPING("org.springframework.web.bind.annotation.DeleteMapping"),
+    GET_MAPPING("org.springframework.web.bind.annotation.GetMapping"),
+    POST_MAPPING("org.springframework.web.bind.annotation.PostMapping"),
+    PUT_MAPPING("org.springframework.web.bind.annotation.PutMapping"),
+    PATCH_MAPPING("org.springframework.web.bind.annotation.PatchMapping"),
+    REQUEST_MAPPING("org.springframework.web.bind.annotation.RequestMapping");
+    @Getter
+    private final String fullyQualifiedName;
+
+    SpringRestMethodAnnotation(String fqn) {
+        this.fullyQualifiedName = fqn;
+    }
+
+    public static List<SpringRestMethodAnnotation> getAll() {
+        return Arrays.asList(values());
+    }
+}

--- a/components/sbm-support-boot/src/main/java/org/springframework/sbm/boot/web/finder/FindRestControllerBeans.java
+++ b/components/sbm-support-boot/src/main/java/org/springframework/sbm/boot/web/finder/FindRestControllerBeans.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.sbm.boot.web.finder;
+
+import org.springframework.sbm.boot.web.api.RestControllerBean;
+import org.springframework.sbm.java.filter.JavaSourceListFilter;
+import org.springframework.sbm.project.resource.ProjectResourceSet;
+import org.springframework.sbm.project.resource.filter.ProjectResourceFinder;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Find all classes annotated with {@code RestController} and return {@code RestControllerBean} providing an API for rest controller.
+ */
+public class FindRestControllerBeans implements ProjectResourceFinder<List<RestControllerBean>> {
+
+    private static final String REST_CONTROLLER_ANNOTATION = "org.springframework.web.bind.annotation.RestController";
+
+    @Override
+    public List<RestControllerBean> apply(ProjectResourceSet projectResourceSet) {
+        return new JavaSourceListFilter().apply(projectResourceSet).stream()
+                .flatMap(js -> {
+                    return js
+                            .getTypes()
+                            .stream()
+                            .filter(t -> t.hasAnnotation(REST_CONTROLLER_ANNOTATION))
+                            .map(t -> new RestControllerBean(js, t));
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/components/sbm-support-boot/src/test/java/org/springframework/sbm/boot/web/api/RestControllerBeanTest.java
+++ b/components/sbm-support-boot/src/test/java/org/springframework/sbm/boot/web/api/RestControllerBeanTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.sbm.boot.web.api;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.sbm.boot.web.api.RestControllerBean;
+import org.springframework.sbm.boot.web.api.RestMethod;
+import org.springframework.sbm.engine.context.ProjectContext;
+import org.springframework.sbm.java.api.JavaSource;
+import org.springframework.sbm.java.api.Type;
+import org.springframework.sbm.project.resource.TestProjectContext;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.stringtemplate.v4.ST;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RestControllerBeanTest {
+    @Test
+    void restController_simpleGET() {
+        @Language("java")
+        String restController =
+                """
+                package com.example;
+                import org.springframework.web.bind.annotation.GetMapping;
+                import org.springframework.web.bind.annotation.RestController;
+                                
+                @RestController
+                public class AdditionRestController {
+                                
+                    @GetMapping({"/info", "/otherInfo"})
+                    public String getInfo() {
+                        return "info";
+                    }
+                }
+                """;
+
+        ProjectContext context = TestProjectContext
+                .buildProjectContext()
+                .withBuildFileHavingDependencies("org.springframework.boot:spring-boot-starter-web:2.7.3")
+                .addJavaSource("src/main/java", restController)
+                .build();
+
+        JavaSource js = context.getProjectJavaSources().list().get(0);
+        Type type = js.getTypes().get(0);
+        RestControllerBean restControllerBean = new RestControllerBean(js, type);
+        Type restControllerType = restControllerBean.restControllerType();
+        RestMethod restMethod = restControllerBean.getRestMethods().get(0);
+
+        assertThat(restControllerType.getFullyQualifiedName()).isEqualTo("com.example.AdditionRestController");
+        assertThat(restMethod.method().get(0)).isEqualTo(RequestMethod.GET);
+        assertThat(restMethod.consumes()).containsExactly(MediaType.APPLICATION_JSON_VALUE);
+        assertThat(restMethod.produces()).containsExactly(MediaType.APPLICATION_JSON_VALUE);
+        assertThat(restMethod.path()).containsExactlyInAnyOrder("/info", "/otherInfo");
+        assertThat(restMethod.methodReference().getName()).isEqualTo("getInfo");
+    }
+
+    @Test
+    void restController_complexGET() {
+        @Language("java")
+        String restController =
+                """
+                package com.example;
+                import org.springframework.web.bind.annotation.GetMapping;
+                import org.springframework.web.bind.annotation.RestController;
+                import org.springframework.http.MediaType;
+                                
+                @RestController
+                public class AdditionRestController {
+                                
+                    @GetMapping(
+                        name = "getInfoEndpoint",
+                        path={"/info", "/otherInfo"},
+                        params = {"p1", "p2"},
+                        headers = {"a=b", "c=d"},
+                        consumes = {MediaType.APPLICATION_ATOM_XML_VALUE, MediaType.APPLICATION_NDJSON_VALUE}, 
+                        produces = {MediaType.APPLICATION_CBOR_VALUE, MediaType.APPLICATION_PDF_VALUE}
+                    )
+                    public String getInfo() {
+                        return "info";
+                    }
+                }
+                """;
+
+        ProjectContext context = TestProjectContext
+                .buildProjectContext()
+                .withBuildFileHavingDependencies("org.springframework.boot:spring-boot-starter-web:2.7.3")
+                .addJavaSource("src/main/java", restController)
+                .build();
+
+        JavaSource js = context.getProjectJavaSources().list().get(0);
+        Type type = js.getTypes().get(0);
+        RestControllerBean restControllerBean = new RestControllerBean(js, type);
+        Type restControllerType = restControllerBean.restControllerType();
+        RestMethod restMethod = restControllerBean.getRestMethods().get(0);
+
+        assertThat(restControllerType.getFullyQualifiedName()).isEqualTo("com.example.AdditionRestController");
+        assertThat(restMethod.name()).isEqualTo("getInfoEndpoint");
+        assertThat(restMethod.path()).containsExactlyInAnyOrder("/info", "/otherInfo");
+        assertThat(restMethod.params()).containsExactlyInAnyOrder("p1", "p2");
+        assertThat(restMethod.headers()).containsExactlyInAnyOrder("a=b", "c=d");
+        assertThat(restMethod.method().get(0)).isEqualTo(RequestMethod.GET);
+        assertThat(restMethod.consumes()).containsExactly(MediaType.APPLICATION_ATOM_XML_VALUE, MediaType.APPLICATION_NDJSON_VALUE);
+        assertThat(restMethod.produces()).containsExactly(MediaType.APPLICATION_CBOR_VALUE, MediaType.APPLICATION_PDF_VALUE);
+        assertThat(restMethod.methodReference().getName()).isEqualTo("getInfo");
+    }
+
+
+
+    @Test
+    void RequestMapping_POST() {
+        RestMethod restMethod = createRestControllerWithAnnotatedMethod("@RequestMapping(method=RequestMethod.POST)", "org.springframework.web.bind.annotation.RequestMapping", "org.springframework.web.bind.annotation.RequestMethod");
+        assertThat(restMethod.method().get(0)).isEqualTo(RequestMethod.POST);
+    }
+
+    @Test
+    void RequestMapping_GET() {
+        RestMethod restMethod = createRestControllerWithAnnotatedMethod("@RequestMapping(method=RequestMethod.GET)","org.springframework.web.bind.annotation.RequestMapping", "org.springframework.web.bind.annotation.RequestMethod");
+        assertThat(restMethod.method().get(0)).isEqualTo(RequestMethod.GET);
+    }
+
+    @Test
+    void RequestMapping_DELETE() {
+        RestMethod restMethod = createRestControllerWithAnnotatedMethod("@RequestMapping(method=RequestMethod.DELETE)","org.springframework.web.bind.annotation.RequestMapping", "org.springframework.web.bind.annotation.RequestMethod");
+        assertThat(restMethod.method().get(0)).isEqualTo(RequestMethod.DELETE);
+    }
+
+    @Test
+    void RequestMapping_HEAD() {
+        RestMethod restMethod = createRestControllerWithAnnotatedMethod("@RequestMapping(method=RequestMethod.HEAD)","org.springframework.web.bind.annotation.RequestMapping", "org.springframework.web.bind.annotation.RequestMethod");
+        assertThat(restMethod.method().get(0)).isEqualTo(RequestMethod.HEAD);
+    }
+
+    @Test
+    void RequestMapping_OPTIONS() {
+        RestMethod restMethod = createRestControllerWithAnnotatedMethod("@RequestMapping(method=RequestMethod.OPTIONS)", "org.springframework.web.bind.annotation.RequestMapping", "org.springframework.web.bind.annotation.RequestMethod");
+        assertThat(restMethod.method().get(0)).isEqualTo(RequestMethod.OPTIONS);
+    }
+
+    @Test
+    void RequestMapping_PUT() {
+        RestMethod restMethod = createRestControllerWithAnnotatedMethod("@RequestMapping(method=RequestMethod.PUT)","org.springframework.web.bind.annotation.RequestMapping", "org.springframework.web.bind.annotation.RequestMethod");
+        assertThat(restMethod.method().get(0)).isEqualTo(RequestMethod.PUT);
+    }
+
+    @Test
+    void RequestMapping_PATCH() {
+        RestMethod restMethod = createRestControllerWithAnnotatedMethod("@RequestMapping(method=RequestMethod.PATCH)","org.springframework.web.bind.annotation.RequestMapping", "org.springframework.web.bind.annotation.RequestMethod");
+        assertThat(restMethod.method().get(0)).isEqualTo(RequestMethod.PATCH);
+    }
+
+    @Test
+    void RequestMapping_TRACE() {
+        RestMethod restMethod = createRestControllerWithAnnotatedMethod("@RequestMapping(method=RequestMethod.TRACE)","org.springframework.web.bind.annotation.RequestMapping", "org.springframework.web.bind.annotation.RequestMethod");
+        assertThat(restMethod.method().get(0)).isEqualTo(RequestMethod.TRACE);
+    }
+
+    private RestMethod createRestControllerWithAnnotatedMethod(String requestMapping, String... imports) {
+        @Language("java")
+        String restController =
+                """
+                package com.example;
+                import org.springframework.web.bind.annotation.RestController;
+                <imports>
+                                
+                @RestController
+                public class AdditionRestController {
+                                
+                    <requestMapping>
+                    public String getInfo() {
+                        return "info";
+                    }
+                }
+                """;
+
+        ST st = new ST(restController);
+        st.add("requestMapping", requestMapping);
+        st.add("imports", Arrays.stream(imports).map(i -> "import " + i + ";").collect(Collectors.joining("\n")));
+
+        String restControllerCode = st.render();
+
+        ProjectContext context = TestProjectContext
+                .buildProjectContext()
+                .withBuildFileHavingDependencies("org.springframework.boot:spring-boot-starter-web:2.7.3")
+                .addJavaSource("src/main/java", restControllerCode)
+                .build();
+        JavaSource js = context.getProjectJavaSources().list().get(0);
+        Type type = js.getTypes().get(0);
+        RestControllerBean restControllerBean = new RestControllerBean(js, type);
+        RestMethod restMethod = restControllerBean.getRestMethods().get(0);
+
+        return restMethod;
+    }
+}

--- a/components/sbm-support-boot/src/test/java/org/springframework/sbm/boot/web/finder/FindRestControllerBeansTest.java
+++ b/components/sbm-support-boot/src/test/java/org/springframework/sbm/boot/web/finder/FindRestControllerBeansTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.sbm.boot.web.finder;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.sbm.engine.context.ProjectContext;
+import org.springframework.sbm.project.resource.TestProjectContext;
+import org.springframework.sbm.boot.web.api.RestControllerBean;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FindRestControllerBeansTest {
+    @Test
+    void test_renameMe() {
+        String restController =
+                """
+                        package com.example.rest;
+                        import org.springframework.web.bind.annotation.RestController;
+                        import org.springframework.web.bind.annotation.GetMapping;
+                                        
+                        @RestController
+                        public class MyRestEndpoint {
+                            @GetMapping({"/one","/other"})
+                            String getRoot() {
+                                return "";   
+                            }
+                        }
+                        """;
+        ProjectContext context = TestProjectContext
+                .buildProjectContext()
+                .withBuildFileHavingDependencies("org.springframework:spring-web:5.3.22")
+                .addJavaSource("src/main/java", restController)
+                .build();
+
+        List<RestControllerBean> restControllerBeans = context.search(new FindRestControllerBeans());
+
+        assertThat(restControllerBeans).hasSize(1);
+        assertThat(restControllerBeans.get(0).getRestMethods().get(0).path()).containsExactlyInAnyOrder("/one", "/other");
+        assertThat(restControllerBeans.get(0).getRestMethods().get(0).method()).containsExactly(RequestMethod.GET);
+    }
+}

--- a/docs/reference/concepts.adoc
+++ b/docs/reference/concepts.adoc
@@ -133,3 +133,23 @@ When git support is enabled SBM commits the changes applied by running the recip
 
 Since 0.9.0 SBM starts to support https://maven.apache.org/guides/mini/guide-multiple-modules.html#the-reactor[multi module applications].
 
+
+=== Spring Boot Resources
+
+==== Spring RestController Bean
+Classes annotated with Spring `@RestController` annotation can be found using the `FindRestControllerBeans` finder.
+
+[source,java]
+.....
+List<RestControllerBean> restController = projectContext.search(new FindRestControllerBeans());
+
+List<RestMethod> restMethods = restController.get(0).getRestMethods();
+
+restMethods.get(0).
+.....
+
+
+
+
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -278,6 +278,12 @@
                 <artifactId>jaxb-runtime</artifactId>
                 <version>2.3.3</version>
             </dependency>
+            <dependency>
+                <groupId>org.antlr</groupId>
+                <artifactId>ST4</artifactId>
+                <version>4.3.3</version>
+                <scope>compile</scope>
+            </dependency>
             <!-- or uses different version then spring boot, explicitly overwrite version -->
             <!--
             <dependency>


### PR DESCRIPTION
closes #386 

* Adds `FindRestControllerBeans` finder
* Adds `RestControllerBean` and `RestMethod` providing an API for rest controllers
* Currently only supports request mapping annotations on method level