### PR TITLE
Test for getDependency variations

### DIFF
--- a/components/sbm-core/src/main/java/org/springframework/sbm/build/impl/OpenRewriteMavenBuildFile.java
+++ b/components/sbm-core/src/main/java/org/springframework/sbm/build/impl/OpenRewriteMavenBuildFile.java
@@ -280,20 +280,20 @@ public class OpenRewriteMavenBuildFile extends RewriteSourceFileHolder<Xml.Docum
                                 resolvedArtifactId,
                                 d.getScope() != null ? Scope.fromName(d.getScope()) : null
                         );
-//                        if (dependencies.isEmpty()) {
-//                            // requested dependency from another module in this multi-module project won't be resolvable
-//                            d.setGroupId(resolvedGroupId);
-//                            d.setArtifactId(resolvedArtifactId);
-//                            d.setVersion(resolvedVersion);
-////                            return d;
-//                        } else {
+                        if (dependencies.isEmpty()) {
+                            // requested dependency from another module in this multi-module project won't be resolvable
+                            d.setGroupId(resolvedGroupId);
+                            d.setArtifactId(resolvedArtifactId);
+                            d.setVersion(resolvedVersion);
+                        }
+                        else {
                             ResolvedDependency resolvedDependency = dependencies.get(0);
                             d.setGroupId(resolvedGroupId);
                             d.setArtifactId(resolvedArtifactId);
                             d.setVersion(resolvedDependency.getVersion());
                             d.setClassifier(resolvedDependency.getClassifier());
                             d.setType(resolvedDependency.getType());
-//                        }
+                        }
 
 
                         if(d.getScope() == null ) {

--- a/components/sbm-core/src/main/java/org/springframework/sbm/project/parser/DependencyHelper.java
+++ b/components/sbm-core/src/main/java/org/springframework/sbm/project/parser/DependencyHelper.java
@@ -67,7 +67,7 @@ public class DependencyHelper {
     }
 
     public Set<Dependency> mapCoordinatesToDependencies(List<String> coordinates) {
-        Set<Dependency> dependencies = new HashSet<>();
+        Set<Dependency> dependencies = new LinkedHashSet<>();
         coordinates.forEach(c -> {
 
             String[] parts = c.split(":");

--- a/components/sbm-core/src/test/java/org/springframework/sbm/build/api/Module_contains_Test.java
+++ b/components/sbm-core/src/test/java/org/springframework/sbm/build/api/Module_contains_Test.java
@@ -73,7 +73,7 @@ class Module_contains_Test {
 
         String module1Pom = PomBuilder
                 .buiildPom("com.example:parent:1.0", "module1")
-                .dependencies("com.example:module2:1.0")
+                .unscopedDependencies("com.example:module2:1.0")
                 .build();
 
         String module2Pom = PomBuilder.buiildPom("com.example:parent:1.0", "module2").build();

--- a/components/sbm-core/src/test/java/org/springframework/sbm/build/util/PomBuilder.java
+++ b/components/sbm-core/src/test/java/org/springframework/sbm/build/util/PomBuilder.java
@@ -14,105 +14,176 @@
  * limitations under the License.
  */
 
-package org.springframework.sbm.build.util;import org.springframework.sbm.project.parser.DependencyHelper;
+package org.springframework.sbm.build.util;
 
-import java.util.Arrays;
-import java.util.List;
+import org.openrewrite.maven.tree.Scope;
+import org.springframework.sbm.build.api.Dependency;
+import org.springframework.sbm.project.parser.DependencyHelper;
+
+import java.util.*;
 
 public class PomBuilder {
-        private String coordinate;
-        private List<String> modules;
-        private String type;
-        private String parent;
-        private String artifactId;
-        private List<String> dependencies;
+    private String coordinate;
+    private List<String> modules;
+    private String type;
+    private String parent;
+    private String artifactId;
+    private List<String> unscopedDependencies;
+    private List<String> testScopeDependencies;
+    private Map<String, String> properties = new HashMap<>();
+    private Map<Scope, org.openrewrite.maven.tree.Dependency> dependencies = new LinkedHashMap<Scope, org.openrewrite.maven.tree.Dependency>();
 
-        public static PomBuilder buiildPom(String coordinate) {
-            PomBuilder pomBuilder = new PomBuilder();
-            pomBuilder.coordinate = coordinate;
-            return pomBuilder;
+    private DependencyHelper dependencyHelper = new DependencyHelper();
+
+    public static PomBuilder buiildPom(String coordinate) {
+        PomBuilder pomBuilder = new PomBuilder();
+        pomBuilder.coordinate = coordinate;
+        return pomBuilder;
+    }
+
+    public static PomBuilder buiildPom(String parent, String artifactId) {
+        PomBuilder pomBuilder = new PomBuilder();
+        pomBuilder.parent = parent;
+        pomBuilder.artifactId = artifactId;
+        return pomBuilder;
+    }
+
+    public PomBuilder withModules(String... modules) {
+        this.modules = Arrays.asList(modules);
+        return this;
+    }
+
+    public String build() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("""
+                          <?xml version="1.0" encoding="UTF-8"?>
+                          <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                              <modelVersion>4.0.0</modelVersion>
+                          """);
+
+        if (parent != null) {
+            String[] coord = parent.split(":");
+            sb.append("    <parent>").append("\n");
+            sb.append("        <groupId>").append(coord[0]).append("</groupId>").append("\n");
+            sb.append("        <artifactId>").append(coord[1]).append("</artifactId>").append("\n");
+            sb.append("        <version>").append(coord[2]).append("</version>").append("\n");
+            sb.append("    </parent>").append("\n");
+            sb.append("    <artifactId>").append(artifactId).append("</artifactId>").append("\n");
+        } else {
+            String[] coord = coordinate.split(":");
+            sb.append("    <groupId>").append(coord[0]).append("</groupId>").append("\n");
+            sb.append("    <artifactId>").append(coord[1]).append("</artifactId>").append("\n");
+            sb.append("    <version>").append(coord[2]).append("</version>").append("\n");
         }
 
-        public static PomBuilder buiildPom(String parent, String artifactId) {
-            PomBuilder pomBuilder = new PomBuilder();
-            pomBuilder.parent = parent;
-            pomBuilder.artifactId = artifactId;
-            return pomBuilder;
-        }
-
-        public PomBuilder withModules(String... modules) {
-            this.modules = Arrays.asList(modules);
-            return this;
-        }
-
-        public String build() {
-            StringBuilder sb = new StringBuilder();
-            sb.append(
-                    """
-                    <?xml version="1.0" encoding="UTF-8"?>
-                    <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-                        <modelVersion>4.0.0</modelVersion>
-                    """
+        if(!properties.isEmpty()) {
+            sb.append("    <properties>").append("\n");
+            properties.entrySet().forEach(e ->
+                sb.append("        <").append(e.getKey()).append(">").append(e.getValue()).append("</").append(e.getKey()).append(">").append("\n")
             );
-
-            if(parent != null) {
-                String[] coord = parent.split(":");
-                sb.append("    <parent>").append("\n");
-                sb.append("        <groupId>").append(coord[0]).append("</groupId>").append("\n");
-                sb.append("        <artifactId>").append(coord[1]).append("</artifactId>").append("\n");
-                sb.append("        <version>").append(coord[2]).append("</version>").append("\n");
-                sb.append("    </parent>").append("\n");
-                sb.append("    <artifactId>").append(artifactId).append("</artifactId>").append("\n");
-            } else {
-                String[] coord = coordinate.split(":");
-                sb.append("    <groupId>").append(coord[0]).append("</groupId>").append("\n");
-                sb.append("    <artifactId>").append(coord[1]).append("</artifactId>").append("\n");
-                sb.append("    <version>").append(coord[2]).append("</version>").append("\n");
-            }
-
-
-            if(type != null ){
-                sb.append("    <type>").append(type).append("</type>").append("\n");
-            }
-
-            if(modules != null && !modules.isEmpty()) {
-                sb.append("    <modules>").append("\n");
-                modules.forEach(m -> sb.append("        <module>").append(m).append("</module>\n"));
-                sb.append("    </modules>").append("\n");
-            }
-
-            if(dependencies != null) {
-                String dependenciesRendered = buildDependencies(dependencies);
-                sb.append(dependenciesRendered);
-            }
-
-            sb.append("</project>");
-            return sb.toString();
+            sb.append("    </properties>").append("\n");
         }
 
-        String buildDependencies(List<String> dependencyCoordinates) {
-            DependencyHelper dependencyHelper = new DependencyHelper();
-            StringBuilder dependenciesSection = new StringBuilder();
-            dependenciesSection.append("    ").append("<dependencies>").append("\n");
-            dependencyHelper.mapCoordinatesToDependencies(dependencyCoordinates).stream().forEach(dependency -> {
-                dependenciesSection.append("    ").append("    ").append("<dependency>").append("\n");
-                dependenciesSection.append("    ").append("    ").append("    ").append("<groupId>").append(dependency.getGroupId()).append("</groupId>").append("\n");
-                dependenciesSection.append("    ").append("    ").append("    ").append("<artifactId>").append(dependency.getArtifactId()).append("</artifactId>").append("\n");
-                dependenciesSection.append("    ").append("    ").append("    ").append("<version>").append(dependency.getVersion()).append("</version>").append("\n");
-                dependenciesSection.append("    ").append("    ").append("</dependency>").append("\n");
-            });
-            dependenciesSection.append("    ").append("</dependencies>").append("\n");
-            String dependenciesText = dependenciesSection.toString();
-            return dependenciesText;
+
+        if (type != null) {
+            sb.append("    <type>").append(type).append("</type>").append("\n");
         }
 
-        public PomBuilder type(String type) {
-            this.type = type;
-            return this;
+        if (modules != null && !modules.isEmpty()) {
+            sb.append("    <modules>").append("\n");
+            modules.forEach(m -> sb.append("        <module>").append(m).append("</module>\n"));
+            sb.append("    </modules>").append("\n");
         }
 
-        public PomBuilder dependencies(String... s) {
-            this.dependencies = Arrays.asList(s);
-            return this;
+        if (!dependencies.isEmpty()) {
+            String dependenciesRendered = renderDependencies(dependencies);
+            sb.append(dependenciesRendered);
         }
+
+        sb.append("</project>");
+        return sb.toString();
+    }
+
+    String renderDependencies(Map<Scope, org.openrewrite.maven.tree.Dependency> dependencies) {
+        StringBuilder dependenciesSection = new StringBuilder();
+        dependenciesSection.append("    ").append("<dependencies>").append("\n");
+        dependencies.entrySet().forEach(e -> {
+            renderDependency(dependenciesSection, e.getKey(), e.getValue());
+        });
+        dependenciesSection.append("    ").append("</dependencies>").append("\n");
+        String dependenciesText = dependenciesSection.toString();
+        return dependenciesText;
+    }
+
+    private void renderDependency(StringBuilder dependenciesSection, Scope scope, org.openrewrite.maven.tree.Dependency dependency) {
+
+        dependenciesSection
+                .append("    ")
+                .append("    ")
+                .append("<dependency>")
+                .append("\n");
+        dependenciesSection
+                    .append("    ")
+                    .append("    ")
+                    .append("    ")
+                    .append("<groupId>")
+                    .append(dependency.getGroupId())
+                    .append("</groupId>")
+                    .append("\n");
+            dependenciesSection
+                    .append("    ")
+                    .append("    ")
+                    .append("    ")
+                    .append("<artifactId>")
+                    .append(dependency.getArtifactId())
+                    .append("</artifactId>")
+                    .append("\n");
+            dependenciesSection
+                    .append("    ")
+                    .append("    ")
+                    .append("    ")
+                    .append("<version>")
+                    .append(dependency.getVersion())
+                    .append("</version>")
+                    .append("\n");
+            if(scope != Scope.None) {
+                dependenciesSection
+                        .append("    ")
+                        .append("    ")
+                        .append("    ")
+                        .append("<scope>")
+                        .append(scope.name().toLowerCase())
+                        .append("</scope>")
+                        .append("\n");
+            }
+        dependenciesSection
+                .append("    ")
+                .append("    ")
+                .append("</dependency>")
+                .append("\n");
+    }
+
+    public PomBuilder type(String type) {
+        this.type = type;
+        return this;
+    }
+
+    public PomBuilder unscopedDependencies(String... coordinates) {
+        dependencyHelper.mapCoordinatesToDependencies(Arrays.asList(coordinates))
+                .stream()
+                .forEach(c -> this.dependencies.put(Scope.None, c));
+        return this;
+    }
+
+    public PomBuilder testScopeDependencies(String... coordinates) {
+        dependencyHelper.mapCoordinatesToDependencies(Arrays.asList(coordinates))
+                .stream()
+                .forEach(c -> this.dependencies.put(Scope.Test, c));
+        return this;
+    }
+
+    public PomBuilder withProperties(Map<String, String> properties) {
+        this.properties = properties;
+        return this;
+    }
 }

--- a/components/sbm-core/src/test/java/org/springframework/sbm/project/buildfile/OpenRewriteMavenBuildFileTest.java
+++ b/components/sbm-core/src/test/java/org/springframework/sbm/project/buildfile/OpenRewriteMavenBuildFileTest.java
@@ -16,10 +16,8 @@
 package org.springframework.sbm.project.buildfile;
 
 import org.intellij.lang.annotations.Language;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.*;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.context.ApplicationEventPublisher;
@@ -27,6 +25,7 @@ import org.springframework.sbm.build.api.BuildFile;
 import org.springframework.sbm.build.api.DependenciesChangedEvent;
 import org.springframework.sbm.build.api.Dependency;
 import org.springframework.sbm.build.api.Plugin;
+import org.springframework.sbm.build.util.PomBuilder;
 import org.springframework.sbm.engine.context.ProjectContext;
 import org.springframework.sbm.engine.context.ProjectContextHolder;
 import org.springframework.sbm.java.api.Member;
@@ -34,9 +33,7 @@ import org.springframework.sbm.java.impl.DependenciesChangedEventHandler;
 import org.springframework.sbm.project.resource.TestProjectContext;
 
 import java.nio.file.Path;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -825,6 +822,179 @@ public class OpenRewriteMavenBuildFileTest {
         assertThat(sut.getDependencyManagement()).hasSize(0);
         assertThat(sut.getDeclaredDependencies()).hasSize(0);
     }
+
+    /**
+     * Test get[declared|requested|effective]Dependencies for pom files in multi-module project
+     */
+    @Nested
+    class GetDependenciesMultiModuleTest {
+        String parentPom = PomBuilder
+                .buiildPom("com.example:parent:1.0")
+                .withProperties(Map.of(
+                    "jakarta.version", "3.0.2",
+                    "validation.groupId", "jakarta.validation",
+                    "annotationApi.artifactId", "javax.annotation-api"
+                    )
+                )
+                .withModules("module1", "module2")
+                .build();
+
+        String module1Pom = PomBuilder
+                .buiildPom("com.example:parent:1.0", "module1")
+                .unscopedDependencies("com.example:module2:${project.version}")
+                .testScopeDependencies("javax.annotation:${annotationApi.artifactId}:1.3.2")
+                .build();
+
+        String module2Pom = PomBuilder
+                .buiildPom("com.example:parent:1.0", "module2")
+                .unscopedDependencies("${validation.groupId}:jakarta.validation-api:${jakarta.version}")
+                .build();
+
+        ProjectContext context = TestProjectContext
+                .buildProjectContext()
+                .withMavenRootBuildFileSource(parentPom)
+                .withMavenBuildFileSource("module1", module1Pom)
+                .withMavenBuildFileSource("module2", module2Pom)
+                .build();
+
+        BuildFile module1 = context.getApplicationModules().getModule("module1").getBuildFile();
+        BuildFile module2 = context.getApplicationModules().getModule("module2").getBuildFile();
+
+        @Test
+        @DisplayName("getDeclaredDependencies should return the dependencies as declared in build file")
+        void getDeclaredDependencies() {
+            // Module 1
+            List<Dependency> dependenciesDeclaredInModule1 = module1.getDeclaredDependencies();
+
+            assertThat(dependenciesDeclaredInModule1).hasSize(2);
+
+            Dependency dependency1DeclaredInModule1 = dependenciesDeclaredInModule1.get(0);
+            assertThat(dependency1DeclaredInModule1.getGroupId()).isEqualTo("com.example");
+            assertThat(dependency1DeclaredInModule1.getArtifactId()).isEqualTo("module2");
+            assertThat(dependency1DeclaredInModule1.getVersion()).isEqualTo("${project.version}");
+            assertThat(dependency1DeclaredInModule1.getScope()).isNull();
+            assertThat(dependency1DeclaredInModule1.getClassifier()).isNull();
+            assertThat(dependency1DeclaredInModule1.getExclusions()).isEmpty();
+
+            Dependency dependency2DeclaredInModule1 = dependenciesDeclaredInModule1.get(1);
+            assertThat(dependency2DeclaredInModule1.getGroupId()).isEqualTo("javax.annotation");
+            assertThat(dependency2DeclaredInModule1.getArtifactId()).isEqualTo("${annotationApi.artifactId}");
+            assertThat(dependency2DeclaredInModule1.getVersion()).isEqualTo("1.3.2");
+            assertThat(dependency2DeclaredInModule1.getScope()).isEqualTo("test");
+            assertThat(dependency2DeclaredInModule1.getClassifier()).isNull();
+            assertThat(dependency2DeclaredInModule1.getExclusions()).isEmpty();
+
+            // Module 2
+            List<Dependency> dependenciesDeclaredInModule2 = module2.getDeclaredDependencies();
+
+            assertThat(dependenciesDeclaredInModule2).hasSize(1);
+            Dependency dependencyDeclaredInModule2 = dependenciesDeclaredInModule2.get(0);
+
+            assertThat(dependencyDeclaredInModule2.getGroupId()).isEqualTo("${validation.groupId}");
+            assertThat(dependencyDeclaredInModule2.getArtifactId()).isEqualTo("jakarta.validation-api");
+            assertThat(dependencyDeclaredInModule2.getVersion()).isEqualTo("${jakarta.version}");
+            assertThat(dependencyDeclaredInModule2.getScope()).isNull();
+            assertThat(dependencyDeclaredInModule2.getClassifier()).isNull();
+            assertThat(dependencyDeclaredInModule2.getExclusions()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("getRequestedDependencies should return the declared dependencies with resolved attributes")
+        void getRequestedDependencies() {
+            // Module 1
+            List<Dependency> dependenciesRequestedInModule1 = module1.getRequestedDependencies();
+
+            assertThat(dependenciesRequestedInModule1).hasSize(2);
+            Dependency dependency1DeclaredInModule1 = dependenciesRequestedInModule1.get(0);
+
+            assertThat(dependency1DeclaredInModule1.getGroupId()).isEqualTo("com.example");
+            assertThat(dependency1DeclaredInModule1.getArtifactId()).isEqualTo("module2");
+            assertThat(dependency1DeclaredInModule1.getVersion()).isEqualTo("1.0");
+            assertThat(dependency1DeclaredInModule1.getScope()).isEqualTo("compile");
+            assertThat(dependency1DeclaredInModule1.getClassifier()).isNull();
+            assertThat(dependency1DeclaredInModule1.getExclusions()).isEmpty();
+
+            Dependency dependency2DeclaredInModule1 = dependenciesRequestedInModule1.get(1);
+            assertThat(dependency2DeclaredInModule1.getGroupId()).isEqualTo("javax.annotation");
+            assertThat(dependency2DeclaredInModule1.getArtifactId()).isEqualTo("javax.annotation-api");
+            assertThat(dependency2DeclaredInModule1.getVersion()).isEqualTo("1.3.2");
+            assertThat(dependency2DeclaredInModule1.getScope()).isEqualTo("test");
+            assertThat(dependency2DeclaredInModule1.getClassifier()).isNull();
+            assertThat(dependency2DeclaredInModule1.getExclusions()).isEmpty();
+
+            // Module 2
+            List<Dependency> dependenciesRequestedInModule2 = module2.getRequestedDependencies();
+
+            assertThat(dependenciesRequestedInModule2).hasSize(1);
+            Dependency dependencyDeclaredInModule2 = dependenciesRequestedInModule2.get(0);
+
+            assertThat(dependencyDeclaredInModule2.getGroupId()).isEqualTo("jakarta.validation");
+            assertThat(dependencyDeclaredInModule2.getArtifactId()).isEqualTo("jakarta.validation-api");
+            assertThat(dependencyDeclaredInModule2.getVersion()).isEqualTo("3.0.2");
+            assertThat(dependencyDeclaredInModule2.getScope()).isEqualTo("compile");
+            assertThat(dependencyDeclaredInModule2.getClassifier()).isNull();
+            assertThat(dependencyDeclaredInModule2.getExclusions()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("getRequestedDependencies should return any available dependency (declared or transitive) with given scope")
+        void getEffectiveDependencies() {
+            // Module 1
+            List<Dependency> dependenciesEffectiveInModule1 = new ArrayList(module1.getEffectiveDependencies());
+
+
+            assertThat(dependenciesEffectiveInModule1).hasSize(3);
+            Dependency depToModule2 = findDependencyByCoordinate(dependenciesEffectiveInModule1,"com.example:module2:1.0");
+
+            assertThat(depToModule2.getGroupId()).isEqualTo("com.example");
+            assertThat(depToModule2.getArtifactId()).isEqualTo("module2");
+            assertThat(depToModule2.getVersion()).isEqualTo("1.0");
+            assertThat(depToModule2.getScope()).isEqualTo("compile");
+            assertThat(depToModule2.getClassifier()).isNull();
+            assertThat(depToModule2.getExclusions()).isEmpty();
+
+            Dependency depToAnnotationApi = findDependencyByCoordinate(dependenciesEffectiveInModule1, "javax.annotation:javax.annotation-api:1.3.2");
+
+            assertThat(depToAnnotationApi.getGroupId()).isEqualTo("javax.annotation");
+            assertThat(depToAnnotationApi.getArtifactId()).isEqualTo("javax.annotation-api");
+            assertThat(depToAnnotationApi.getVersion()).isEqualTo("1.3.2");
+            assertThat(depToAnnotationApi.getScope()).isEqualTo("test");
+            assertThat(depToAnnotationApi.getClassifier()).isNull();
+            assertThat(depToAnnotationApi.getExclusions()).isEmpty();
+
+            Dependency transDepToValidationApi = findDependencyByCoordinate(dependenciesEffectiveInModule1, "jakarta.validation:jakarta.validation-api:3.0.2");
+
+            assertThat(transDepToValidationApi.getGroupId()).isEqualTo("jakarta.validation");
+            assertThat(transDepToValidationApi.getArtifactId()).isEqualTo("jakarta.validation-api");
+            assertThat(transDepToValidationApi.getVersion()).isEqualTo("3.0.2");
+            assertThat(transDepToValidationApi.getScope()).isEqualTo("compile");
+            assertThat(transDepToValidationApi.getClassifier()).isNull();
+            assertThat(transDepToValidationApi.getExclusions()).isEmpty();
+
+            // Module 2
+            List<Dependency> dependenciesEffectiveInModule2 = new ArrayList<>(module2.getEffectiveDependencies());
+
+            assertThat(dependenciesEffectiveInModule2).hasSize(1);
+            Dependency dependencyDeclaredInModule2 = findDependencyByCoordinate(dependenciesEffectiveInModule2, "jakarta.validation:jakarta.validation-api:3.0.2");
+
+            assertThat(dependencyDeclaredInModule2.getGroupId()).isEqualTo("jakarta.validation");
+            assertThat(dependencyDeclaredInModule2.getArtifactId()).isEqualTo("jakarta.validation-api");
+            assertThat(dependencyDeclaredInModule2.getVersion()).isEqualTo("3.0.2");
+            assertThat(dependencyDeclaredInModule2.getScope()).isEqualTo("compile");
+            assertThat(dependencyDeclaredInModule2.getClassifier()).isNull();
+            assertThat(dependencyDeclaredInModule2.getExclusions()).isEmpty();
+        }
+
+        @NotNull
+        private Dependency findDependencyByCoordinate(List<Dependency> dependenciesEffectiveInModule1, String anObject) {
+            return dependenciesEffectiveInModule1
+                    .stream()
+                    .filter(d -> d.getCoordinates().equals(anObject))
+                    .findFirst()
+                    .get();
+        }
+    }
+
 
     @Test
     void getRequestedDependencies() {

--- a/components/sbm-core/testcode/jee-ear-project/given/business-logic/pom.xml
+++ b/components/sbm-core/testcode/jee-ear-project/given/business-logic/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>ear-parent</artifactId>
+        <version>1.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>business-logic</artifactId>
+    <packaging>ejb</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.tomee</groupId>
+            <artifactId>javaee-api</artifactId>
+            <version>[8.0,)</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/components/sbm-core/testcode/jee-ear-project/given/ear/pom.xml
+++ b/components/sbm-core/testcode/jee-ear-project/given/ear/pom.xml
@@ -1,0 +1,55 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>ear-parent</artifactId>
+        <version>1.0</version>
+    </parent>
+    <artifactId>ear</artifactId>
+    <packaging>ear</packaging>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.example</groupId>
+            <artifactId>business-logic</artifactId>
+            <version>${project.version}</version>
+            <type>ejb</type>
+        </dependency>
+        <dependency>
+            <groupId>com.example</groupId>
+            <artifactId>webapp</artifactId>
+            <type>war</type>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-ear-plugin</artifactId>
+                <version>2.10.1</version>
+                <configuration>
+                    <version>6</version>
+                    <generateApplicationXml>true</generateApplicationXml>
+                    <defaultLibBundleDir>lib</defaultLibBundleDir>
+                    <modules>
+                        <webModule>
+                            <groupId>com.example</groupId>
+                            <artifactId>webapp</artifactId>
+                            <contextRoot>/webapp</contextRoot>
+                        </webModule>
+                        <ejbModule>
+                            <groupId>com.example</groupId>
+                            <artifactId>business-logic</artifactId>
+                        </ejbModule>
+                    </modules>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/sbm-core/testcode/jee-ear-project/given/pom.xml
+++ b/components/sbm-core/testcode/jee-ear-project/given/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.example</groupId>
+  <artifactId>ear-parent</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>business-logic</module>
+    <module>webapp</module>
+    <module>ear</module>
+  </modules>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <defaultGoal>install</defaultGoal>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.5.1</version>
+          <configuration>
+            <source>1.7</source>
+            <target>1.7</target>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+</project>

--- a/components/sbm-core/testcode/jee-ear-project/given/webapp/pom.xml
+++ b/components/sbm-core/testcode/jee-ear-project/given/webapp/pom.xml
@@ -1,0 +1,33 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>ear-parent</artifactId>
+        <version>1.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>webapp</artifactId>
+    <packaging>war</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.tomee</groupId>
+            <artifactId>javaee-api</artifactId>
+            <version>7.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>jstl</artifactId>
+            <version>1.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>taglibs</groupId>
+            <artifactId>standard</artifactId>
+            <version>1.1.2</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/components/sbm-core/testcode/jee-ear-project/given/webapp/src/main/webapp/WEB-INF/web.xml
+++ b/components/sbm-core/testcode/jee-ear-project/given/webapp/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+    <display-name>test-service</display-name>
+</web-app>

--- a/components/sbm-recipes-boot-upgrade/src/main/java/org/springframework/sbm/boot/upgrade_27_30/report/SpringBootUpgradeReportAction.java
+++ b/components/sbm-recipes-boot-upgrade/src/main/java/org/springframework/sbm/boot/upgrade_27_30/report/SpringBootUpgradeReportAction.java
@@ -157,13 +157,6 @@ public class SpringBootUpgradeReportAction implements Action {
         upgradeReportRenderer.writeReport(renderedTemplate, outputDir, filename);
     }
 
-    private String replaceRelativeLinksToWebResourcesWithAbsoluteLinks(String renderedReport) {
-        return renderedReport;
-//                .replace("\"css/site.css", "\"https://docs.spring.io/spring-framework/docs/current/reference/html/css/spring.css")
-//                .replace("\"js/", "\"https://docs.spring.io/spring-framework/docs/current/reference/html/js/")
-//                .replace("\"img/", "\"https://docs.spring.io/spring-framework/docs/current/reference/html/img/");
-    }
-
     private String renderTemplate(String key, String content, Map<String, Object> data) {
 
         try (StringWriter writer = new StringWriter()) {


### PR DESCRIPTION
PR #492 surfaced some issues with the `getDependencies` variations in `OpenRewriteMavenBuildFile`.
This PR adds tests and fixes the surfaced issues with these methods.
Also, the `TestProjectContext` now offers a method to create the `ProjectContext` from a given directory to ease testing of setups with multiple potentially larger files (as the ear example project).
Additionally, the `PomBuilder` helper class was enhanced to allow building more complete pom files.

@tan9 Could you try to see if things still/now work for you with this PR?
