### PR TITLE
Use a more inclusive emoji for the manual recipes

### DIFF
--- a/applications/spring-shell/src/main/java/org/springframework/sbm/shell/RecipeRenderer.java
+++ b/applications/spring-shell/src/main/java/org/springframework/sbm/shell/RecipeRenderer.java
@@ -28,7 +28,7 @@ import java.util.List;
 @Component
 public class RecipeRenderer {
 
-    public static final String MANUAL_EMOJI = "\uD83D\uDCAA";
+    public static final String MANUAL_EMOJI = "\uD83D\uDCA6";
 
     public static final String AUTOMATED_EMOJI = "\uD83E\uDD16";
 


### PR DESCRIPTION
+ change the manual recipe step 💪🏽💪 to one that is arguably more inclusive 💦, so persons that use this experimental project are more encouraged to do the not-automated recipes, regardless of their number of arms 0️⃣1️⃣2️⃣, prosthetic or not 🦾, the color of their skin and how much muscle they have.

If there are persons that don't adapt to that modeling, tell me I would love to meet them and revise the request so that they are included. (Idea inspired by @christinalee in KotlinConf 2018)