### PR TITLE
560 use correct boot version in new report

### DIFF
--- a/components/sbm-recipes-boot-upgrade/src/main/resources/recipes/27_30/report/sbu30-report.yaml
+++ b/components/sbm-recipes-boot-upgrade/src/main/resources/recipes/27_30/report/sbu30-report.yaml
@@ -73,10 +73,10 @@
         |===
         
         The application was scanned and matched against the changes listed in the
-        https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.5-Release-Notes[Spring Boot 2.5 Release Notes]
+        https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Release-Notes[Spring Boot 3.0 Release Notes]
         as well as from https://github.com/spring-projects/spring-framework/wiki/Upgrading-to-Spring-Framework-5.x[Spring Framework 5.x Release Notes].
         
-        The Relevant Changes section lists all potentially required changes to upgrade the scanned application to Spring Boot 2.5.6.
+        The Relevant Changes section lists all potentially required changes to upgrade the scanned application to Spring Boot 3.0.
         
         NOTE: JDK 17 is required for Spring Boot 3
         

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <rewrite-migrate-java.version>1.13.0</rewrite-migrate-java.version>
         <spring-boot.version>2.7.5</spring-boot.version>
         <progressbar.version>0.9.5</progressbar.version>
-        <testcontainers.version>1.17.5</testcontainers.version>
+        <testcontainers.version>1.17.6</testcontainers.version>
         <maven-invoker.version>3.2.0</maven-invoker.version>
         <shrinkwrap.resolvers.version>3.1.4</shrinkwrap.resolvers.version>
         <lombok.version>1.18.24</lombok.version>


### PR DESCRIPTION
- Changed link to point to 3.0 Release Notes
- Closes #560: 2.7 reference mentioned in issue has already been corrected