### PR TITLE
#703 fix issue when running tests via mvn

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -335,6 +335,8 @@
                     <excludedGroups>integration</excludedGroups>
                     <parallel>methods</parallel>
                     <threadCount>10</threadCount>
+                    <reuseForks>false</reuseForks>
+                    <forkCount>1C</forkCount>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Not sure if I am fixing the issue or hiding it somehow. If I use the option <reuseForks>true</reuseForks> it fails, so I disable it.
add the <forkCount>1C</forkCount> as 1C means to use all CPUs available.
