### PR TITLE
fix: Test fixed by bumping boot version

### DIFF
--- a/components/sbm-openrewrite/src/test/java/org/springframework/sbm/support/openrewrite/api/UpgradeDependencyVersionTest.java
+++ b/components/sbm-openrewrite/src/test/java/org/springframework/sbm/support/openrewrite/api/UpgradeDependencyVersionTest.java
@@ -151,6 +151,9 @@ public class UpgradeDependencyVersionTest {
 
     @Test
     void testUpgradeDependency_latestReleaseVersion() {
+
+        String springBootVersion = getLatestBootReleaseVersion();
+
         @Language("xml")
         String expectedPomXml =
                         """
@@ -176,11 +179,11 @@ public class UpgradeDependencyVersionTest {
                                     <groupId>org.springframework.boot</groupId>
                                     <artifactId>spring-boot-starter-test</artifactId>
                                     <scope>test</scope>
-                                    <version>3.0.2</version>
+                                    <version>%s</version>
                                 </dependency>
                             </dependencies>
                         </project>
-                        """;
+                        """.formatted(springBootVersion);
 
         String groupId = "org.springframework.boot";
         String artifactId = "spring-boot-starter-test";
@@ -190,6 +193,10 @@ public class UpgradeDependencyVersionTest {
         RecipeRun results = sut.run(mavens);
 
         assertThat(results.getResults().get(0).getAfter().printAll()).isEqualTo(expectedPomXml);
+    }
+
+    private String getLatestBootReleaseVersion() {
+        return "3.0.3";
     }
 
     @Test

--- a/components/sbm-openrewrite/src/test/java/org/springframework/sbm/support/openrewrite/api/UpgradeDependencyVersionTest.java
+++ b/components/sbm-openrewrite/src/test/java/org/springframework/sbm/support/openrewrite/api/UpgradeDependencyVersionTest.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
+// does this trigger a build?
 public class UpgradeDependencyVersionTest {
 
     @Language("xml")


### PR DESCRIPTION
Fixed test expdecting boot in `latest.release` (for now) by setting the boot version in expected pom.xml to 3.0.3.
A method exists to retrieve the latest version. A helper should be called there to retrieve the version.