### PR TITLE
Spring migration fix and Mule Changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,5 @@ out/
 .factorypath
 pom.xml.versionsBackup
 **/src/generated/java/META-INF
-/.java-version
+**.java-version
 .rewrite-cache

--- a/applications/spring-shell/src/test/java/org/springframework/sbm/BootUpgrade_27_30_IntegrationTest.java
+++ b/applications/spring-shell/src/test/java/org/springframework/sbm/BootUpgrade_27_30_IntegrationTest.java
@@ -118,7 +118,7 @@ public class BootUpgrade_27_30_IntegrationTest extends IntegrationTestBaseClass 
 
         assertThat(johnzonDependency.getClassifier()).isEqualTo("jakarta");
         assertThat(johnzonDependency.getArtifactId()).isEqualTo("johnzon-core");
-        assertThat(johnzonDependency.getVersion()).isEqualTo("1.2.18");
+        assertThat(johnzonDependency.getVersion()).isEqualTo("1.2.19");
     }
 
     @NotNull

--- a/components/sbm-recipes-boot-upgrade/src/main/java/org/springframework/sbm/boot/upgrade_27_30/report/helper/SpringFactoriesHelper.java
+++ b/components/sbm-recipes-boot-upgrade/src/main/java/org/springframework/sbm/boot/upgrade_27_30/report/helper/SpringFactoriesHelper.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sbm.boot.upgrade_27_30.report.helper;
+
+import org.springframework.sbm.boot.upgrade_27_30.report.SpringBootUpgradeReportSectionHelper;
+import org.springframework.sbm.common.filter.PathPatternMatchingProjectResourceFinder;
+import org.springframework.sbm.engine.context.ProjectContext;
+import org.springframework.sbm.project.resource.ProjectResource;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+public class SpringFactoriesHelper extends SpringBootUpgradeReportSectionHelper<List<String>>  {
+
+    private List<String> files;
+
+    @Override
+    public boolean evaluate(ProjectContext context) {
+        List<ProjectResource> search = context
+                .search(
+                        new PathPatternMatchingProjectResourceFinder(
+                                "/**/src/main/resources/META-INF/spring.factories"
+                        ));
+
+        files = search.stream().map(k -> k.getAbsolutePath().toString()).toList();
+
+        return search
+                .stream()
+                .anyMatch(r -> isRightProperty(r.print()));
+    }
+
+    private boolean isRightProperty(String propertyString) {
+
+        Properties prop = new Properties();
+        try {
+            prop.load(new ByteArrayInputStream(propertyString.getBytes()));
+            String enableAutoConfig = prop.getProperty("org.springframework.boot.autoconfigure.EnableAutoConfiguration");
+
+            return enableAutoConfig != null;
+        } catch (IOException e) {
+
+            return false;
+        }
+    }
+
+    @Override
+    public Map<String, List<String>> getData() {
+        return Map.of("files", files);
+    }
+}

--- a/components/sbm-recipes-boot-upgrade/src/main/resources/recipes/27_30/migration/sbu30-auto-configuration.yaml
+++ b/components/sbm-recipes-boot-upgrade/src/main/resources/recipes/27_30/migration/sbu30-auto-configuration.yaml
@@ -1,0 +1,9 @@
+- name: sbu30-auto-configuration
+  description: Move EnableAutoConfiguration Property from spring.factories to AutoConfiguration.imports
+  condition:
+    type: org.springframework.sbm.common.migration.conditions.TrueCondition
+  actions:
+    - type: org.springframework.sbm.boot.upgrade.common.actions.CreateAutoconfigurationAction
+      condition:
+        type: org.springframework.sbm.boot.upgrade_27_30.report.helper.SpringFactoriesHelper
+      description: Move EnableAutoConfiguration Property from spring.factories to AutoConfiguration.imports

--- a/components/sbm-recipes-boot-upgrade/src/main/resources/recipes/27_30/migration/sbu30-migrate-to-jakarta-packages.yaml
+++ b/components/sbm-recipes-boot-upgrade/src/main/resources/recipes/27_30/migration/sbu30-migrate-to-jakarta-packages.yaml
@@ -9,4 +9,4 @@
         type: org.springframework.sbm.boot.common.conditions.IsSpringBootProject
         versionPattern: "3\\.0\\..*"
       description: Replace javax with new jakarta packages
-      openRewriteRecipeName: org.openrewrite.java.migrate.JavaxMigrationToJakarta
+      openRewriteRecipeName: org.openrewrite.java.migrate.jakarta.JavaxMigrationToJakarta

--- a/components/sbm-recipes-boot-upgrade/src/main/resources/recipes/27_30/report/sbu30-report.yaml
+++ b/components/sbm-recipes-boot-upgrade/src/main/resources/recipes/27_30/report/sbu30-report.yaml
@@ -102,17 +102,16 @@
 #          contributors:
 #            - "Fabian Krüger[@fabapp2]"
 
-        - title: Upgrade Dependencies
+        - title: Prepare for Spring 3.0 dependency
           helper: org.springframework.sbm.boot.upgrade_27_30.report.helper.UpgradeDependenciesHelper
           change: |-
-            Spring Boot 3.0 upgraded many used dependencies. 
-            Also, dependencies previously in the `javax` packages use the new `jakarta` packages now.
-            WARNING: THis is a dummy and needs to be replaced with the matching changes from the release notes!
+            Some of the dependencies artifacts are removed/deprecated/moved to new co ordinates, this automated recipe helps prepare SBM to migrate
           affected: |-
-            List the found dependencies here?
+            *
           remediation:
             description: |-
-              A comprehensive list of affected dependencies and their new replacements
+              * adds ehcache classifier
+              * auto corrects right co ordinates of wiremock if used
             recipe: sbu30-upgrade-dependencies
           contributors:
             - "Fabian Krüger[@fabapp2]"
@@ -244,6 +243,28 @@
           contributors:
             - "Fabian Krüger[@fabapp2]"
 
+        - title: Deprecation of Spring.factories
+          helper: org.springframework.sbm.boot.upgrade_27_30.report.helper.SpringFactoriesHelper
+          change: |-
+            In Spring 2.7 custom auto configurations defined in spring.factories file has been moved to `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`
+          affected: |-
+            The scan found spring.factories file:
+
+            <#list files as file>
+            * `${file}`
+            </#list>
+          remediation:
+            description: ""
+            possibilities:
+              - title: Move spring.factories properties
+                description: |-
+                  Move the contents of spring.factories file into `org.springframework.boot.autoconfigure.AutoConfiguration.imports`
+                resources:
+                  - https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#auto-configuration-registration[Auto Configuration Registration Docs]
+                recipe: sbu30-auto-configuration
+          gitHubIssue: 150
+          contributors:
+            - "Sandeep Nagaraj[@sanagaraj-pivotal]"
         - title: Banner support
           helper: org.springframework.sbm.boot.upgrade_27_30.report.helper.BannerSupportHelper
           change: |-

--- a/components/sbm-recipes-boot-upgrade/src/test/java/org/springframework/sbm/boot/upgrade_27_30/report/helper/SpringFactoriesHelperTest.java
+++ b/components/sbm-recipes-boot-upgrade/src/test/java/org/springframework/sbm/boot/upgrade_27_30/report/helper/SpringFactoriesHelperTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sbm.boot.upgrade_27_30.report.helper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.sbm.engine.context.ProjectContext;
+import org.springframework.sbm.java.api.JavaSource;
+import org.springframework.sbm.project.resource.TestProjectContext;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SpringFactoriesHelperTest {
+
+    @Test
+    public void detectsFileWithSpringFactories() {
+
+        ProjectContext context = TestProjectContext.buildProjectContext()
+                .addProjectResource(
+                        "src/main/resources/META-INF/spring.factories",
+                        """
+                                hello.world=something
+                                org.springframework.boot.autoconfigure.EnableAutoConfiguration=XYZ
+                                """
+                )
+                .build();
+
+        SpringFactoriesHelper sut = new SpringFactoriesHelper();
+        boolean evaluate = sut.evaluate(context);
+
+        assertThat(evaluate).isTrue();
+
+        assertThat(sut.getData()).isNotNull();
+        assertThat(sut.getData().get("files")).hasSize(1);
+        assertThat(sut.getData().get("files").get(0)).contains("src/main/resources/META-INF/spring.factories");
+    }
+}

--- a/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/javadsl/translators/db/MysqlConfigAdapter.java
+++ b/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/javadsl/translators/db/MysqlConfigAdapter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sbm.mule.actions.javadsl.translators.db;
+
+import org.mulesoft.schema.mule.db.MySqlDatabaseConfigType;
+import org.mulesoft.schema.mule.db.OracleDatabaseConfigType;
+import org.springframework.sbm.build.api.Dependency;
+import org.springframework.sbm.mule.api.toplevel.configuration.ConfigurationTypeAdapter;
+import org.springframework.stereotype.Component;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class MysqlConfigAdapter extends ConfigurationTypeAdapter<MySqlDatabaseConfigType>  {
+    @Override
+    public String getName() {
+        return getMuleConfiguration().getName();
+    }
+
+    @Override
+    public Class getMuleConfigurationType() {
+        return MySqlDatabaseConfigType.class;
+    }
+
+    @Override
+    public List<AbstractMap.SimpleEntry<String, String>> configProperties() {
+        List<AbstractMap.SimpleEntry<String, String>> properties = new ArrayList<>();
+        properties.add(new AbstractMap.SimpleEntry<>("spring.datasource.url", "--INSERT--DB-URL-HERE-Example:--INSERT--DB-URL-HERE-Example:jdbc:mysql://localhost:3306/sonoo"));
+        properties.add(new AbstractMap.SimpleEntry<>("spring.datasource.username", "--INSERT-USER-NAME--"));
+        properties.add(new AbstractMap.SimpleEntry<>("spring.datasource.password", "--INSERT-PASSWORD--"));
+        properties.add(new AbstractMap.SimpleEntry<>("spring.datasource.driverClassName", "com.mysql.cj.jdbc.Driver"));
+        properties.add(new AbstractMap.SimpleEntry<>("spring.jpa.show-sql", "true"));
+        return properties;
+    }
+
+    @Override
+    public List<Dependency> getDependencies() {
+
+        return List.of(Dependency.builder()
+                .groupId("mysql")
+                .artifactId("mysql-connector-java")
+                .version("8.0.29")
+                .build());
+    }
+}

--- a/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/javadsl/translators/http/HttpListenerTranslator.java
+++ b/components/sbm-recipes-mule-to-boot/src/main/java/org/springframework/sbm/mule/actions/javadsl/translators/http/HttpListenerTranslator.java
@@ -37,7 +37,7 @@ import java.util.Set;
 public class HttpListenerTranslator implements MuleComponentToSpringIntegrationDslTranslator<ListenerType> {
 
     private final static String javaDslHttpListenerTemplate =
-            "return IntegrationFlows.from(Http.inboundChannelAdapter(\"${path}\")).handle((p, h) -> p)";
+            "return IntegrationFlows.from(Http.inboundGateway(\"${path}\")).handle((p, h) -> p)";
 
     @Override
     public Class<ListenerType> getSupportedMuleType() {

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/JavaDSLActionBaseTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/JavaDSLActionBaseTest.java
@@ -26,6 +26,7 @@ import org.springframework.sbm.mule.actions.javadsl.translators.amqp.AmqpOutboun
 import org.springframework.sbm.mule.actions.javadsl.translators.common.ExpressionLanguageTranslator;
 import org.springframework.sbm.mule.actions.javadsl.translators.core.*;
 import org.springframework.sbm.mule.actions.javadsl.translators.db.InsertTranslator;
+import org.springframework.sbm.mule.actions.javadsl.translators.db.MysqlConfigAdapter;
 import org.springframework.sbm.mule.actions.javadsl.translators.db.OracleConfigAdapter;
 import org.springframework.sbm.mule.actions.javadsl.translators.db.SelectTranslator;
 import org.springframework.sbm.mule.actions.javadsl.translators.dwl.DwlTransformTranslator;
@@ -98,7 +99,8 @@ public class JavaDSLActionBaseTest {
                         new HttpListenerConfigTypeAdapter(),
                         new WmqConnectorTypeAdapter(),
                         new RequestConfigTypeAdapter(),
-                        new OracleConfigAdapter()
+                        new OracleConfigAdapter(),
+                        new MysqlConfigAdapter()
                 )
         );
         MuleMigrationContextFactory muleMigrationContextFactory = new MuleMigrationContextFactory(new MuleConfigurationsExtractor(configurationTypeAdapterFactory));

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/db/MuleToJavaDSLMysqlDBConfigTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/db/MuleToJavaDSLMysqlDBConfigTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sbm.mule.actions.db;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.sbm.mule.actions.JavaDSLActionBaseTest;
+
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class MuleToJavaDSLMysqlDBConfigTest extends JavaDSLActionBaseTest {
+
+    private final String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+            "<mule xmlns:scripting=\"http://www.mulesoft.org/schema/mule/scripting\"\n" +
+            "\txmlns=\"http://www.mulesoft.org/schema/mule/core\" xmlns:api-platform-gw=\"http://www.mulesoft.org/schema/mule/api-platform-gw\" xmlns:apikit=\"http://www.mulesoft.org/schema/mule/apikit\" xmlns:cmis=\"http://www.mulesoft.org/schema/mule/cmis\" xmlns:context=\"http://www.springframework.org/schema/context\" xmlns:db=\"http://www.mulesoft.org/schema/mule/db\" xmlns:doc=\"http://www.mulesoft.org/schema/mule/documentation\" xmlns:dw=\"http://www.mulesoft.org/schema/mule/ee/dw\" xmlns:ee=\"http://www.mulesoft.org/schema/mule/ee/core\" xmlns:http=\"http://www.mulesoft.org/schema/mule/http\" xmlns:spring=\"http://www.springframework.org/schema/beans\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://www.mulesoft.org/schema/mule/scripting http://www.mulesoft.org/schema/mule/scripting/current/mule-scripting.xsd\n" +
+            "http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-current.xsd\n" +
+            "http://www.mulesoft.org/schema/mule/api-platform-gw http://www.mulesoft.org/schema/mule/api-platform-gw/current/mule-api-platform-gw.xsd\n" +
+            "http://www.mulesoft.org/schema/mule/ee/dw http://www.mulesoft.org/schema/mule/ee/dw/current/dw.xsd\n" +
+            "http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-current.xsd\n" +
+            "http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd\n" +
+            "http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd\n" +
+            "http://www.mulesoft.org/schema/mule/apikit http://www.mulesoft.org/schema/mule/apikit/current/mule-apikit.xsd\n" +
+            "http://www.mulesoft.org/schema/mule/cmis http://www.mulesoft.org/schema/mule/cmis/current/mule-cmis.xsd\n" +
+            "http://www.mulesoft.org/schema/mule/db http://www.mulesoft.org/schema/mule/db/current/mule-db.xsd\n" +
+            "http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd\">\n" +
+            "   <db:mysql-config name=\"MySQL_Configuration\" host=\"localhost\" port=\"3306\" user=\"root\" password=\"pw\" database=\"mule\" doc:name=\"MySQL Configuration\"/>\n" +
+            "    <http:listener-config name=\"http-lc-0.0.0.0-8081\" host=\"0.0.0.0\" port=\"8080\" protocol=\"HTTP\"/>\n" +
+            "</mule>";
+
+
+    @Test
+    public void fillApplicationPropertiesForDBConnection() {
+        addXMLFileToResource(xml);
+        runAction();
+        assertThat(getApplicationPropertyContent()).isEqualTo("server.port=8080\n" +
+                "spring.datasource.url=--INSERT--DB-URL-HERE-Example:--INSERT--DB-URL-HERE-Example:jdbc:mysql://localhost:3306/sonoo\n" +
+                "spring.datasource.username=--INSERT-USER-NAME--\n" +
+                "spring.datasource.password=--INSERT-PASSWORD--\n" +
+                "spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver\n" +
+                "spring.jpa.show-sql=true"
+        );
+    }
+
+
+
+    @Test
+    public void importsOracleDrivers() {
+        addXMLFileToResource(xml);
+        runAction();
+
+        Set<String> declaredDependencies = projectContext
+                .getBuildFile().getDeclaredDependencies()
+                .stream()
+                .map(dependency -> dependency.getGroupId() + ":" + dependency.getArtifactId() + ":" + dependency.getVersion())
+                .collect(Collectors.toSet());
+
+        assertThat(declaredDependencies).contains("mysql:mysql-connector-java:8.0.29");
+    }
+}

--- a/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/javadsl/translators/http/HttpListenerTranslatorTest.java
+++ b/components/sbm-recipes-mule-to-boot/src/test/java/org/springframework/sbm/mule/actions/javadsl/translators/http/HttpListenerTranslatorTest.java
@@ -62,7 +62,7 @@ class HttpListenerTranslatorTest {
                 .build();
 
         DslSnippet snippet = apply(projectContext);
-        assertThat(snippet.getRenderedSnippet()).isEqualTo("return IntegrationFlows.from(Http.inboundChannelAdapter(\"/test\")).handle((p, h) -> p)");
+        assertThat(snippet.getRenderedSnippet()).isEqualTo("return IntegrationFlows.from(Http.inboundGateway(\"/test\")).handle((p, h) -> p)");
     }
 
 


### PR DESCRIPTION
This PR addresses 3 issues:

### Mule Mysql Connector support
Now SBM supports `<db:mysql-config />` component and provides right translations to Spring integration project

### Fix of Jakarta Refactor recipe
The import refactor recipe of jakarta packagaes had been broken in main branch, it has been fixed

### Spring factories migration
`Spring.factories` migration was not present in the web UI, but present in CLI. This has been fixed by adding the recipe in Web UI too.  

Closes #738 