### PR TITLE
759 provide a maven pom cache for local maven repository

### DIFF
--- a/components/sbm-openrewrite/src/main/java/org/openrewrite/maven/Cache.java
+++ b/components/sbm-openrewrite/src/main/java/org/openrewrite/maven/Cache.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven;
+/**
+ * @author Fabian Krüger
+ */
+interface Cache<K, V> {
+    void put(K key, V value);
+
+    V getIfPresent(K key);
+}

--- a/components/sbm-openrewrite/src/main/java/org/openrewrite/maven/FilesystemMavenPomCache.java
+++ b/components/sbm-openrewrite/src/main/java/org/openrewrite/maven/FilesystemMavenPomCache.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven;
+
+import lombok.Value;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.maven.cache.MavenPomCache;
+import org.openrewrite.maven.tree.*;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Optional;
+
+/**
+ * A `MavenPomCache` that uses local filesystem, e.g. Maven repository, to store and retrieve pom files.
+ *
+ * The cache directory is optionally configurable. If not set local Maven repository is used.
+ *
+ * The `FilesystemPomCache` must be provided through `ExecutionContext`.
+ *
+ * [source,java]
+ * ....
+ * ExecutionContext executionContext = ...
+ * MavenExecutionContextView.view(executionContext).setPomCache(new LocalMavenPomCache());
+ * ....
+ *
+ * @author Fabian Krüger
+ */
+public class FilesystemMavenPomCache implements MavenPomCache {
+
+    private final Cache<MetadataKey, Optional<MavenMetadata>> mavenMetadataCache;
+    private Cache<ResolvedGroupArtifactVersion, Optional<Pom>> pomCache;
+    private final Cache<MavenRepository, Optional<MavenRepository>> repositoryCache;
+    private final Cache<ResolvedGroupArtifactVersion, ResolvedPom> dependencyCache;
+
+    @Value
+    public static class MetadataKey {
+        URI repository;
+        GroupArtifactVersion gav;
+    }
+
+    /**
+     * Creates `FileSystemPomCache` using local Maven repository `${user.home}/.m2/repository` as cache dir.
+     */
+    public FilesystemMavenPomCache() {
+        this(Path.of(System.getProperty("user.home")).resolve(".m2").resolve("repository"));
+    }
+
+
+    /**
+     * Creates a `FileSystemPomCache` using the provided `cacheDir`.
+     *
+     * @throws IllegalArgumentException if cacheDir does not exist.
+     */
+    public FilesystemMavenPomCache(Path cacheDir) {
+        if(!cacheDir.toFile().exists()) {
+             throw new IllegalArgumentException("The given cache dir '%s' does not exist, Please provide an existing dir.".formatted(cacheDir));
+        }
+        pomCache = new FilesystemPomCache(cacheDir);
+        mavenMetadataCache = new MavenMetadataCache();
+        repositoryCache = new RepositoryCache();
+        dependencyCache = new DependencyCache();
+    }
+
+    @Override
+    public @Nullable ResolvedPom getResolvedDependencyPom(ResolvedGroupArtifactVersion dependency) {
+        return dependencyCache.getIfPresent(dependency);
+    }
+
+    @Override
+    public void putResolvedDependencyPom(ResolvedGroupArtifactVersion dependency, ResolvedPom resolved) {
+        dependencyCache.put(dependency, resolved.deduplicate());
+    }
+
+    @Override
+    public @Nullable Optional<MavenMetadata> getMavenMetadata(URI repo, GroupArtifactVersion gav) {
+        return mavenMetadataCache.getIfPresent(new MetadataKey(repo, gav));
+    }
+
+    @Override
+    public void putMavenMetadata(URI repo, GroupArtifactVersion gav, @Nullable MavenMetadata metadata) {
+        mavenMetadataCache.put(new MetadataKey(repo, gav), Optional.ofNullable(metadata));
+    }
+
+    @Override
+    public @Nullable Optional<Pom> getPom(ResolvedGroupArtifactVersion gav) throws MavenDownloadingException {
+        return pomCache.getIfPresent(gav);
+    }
+
+    @Override
+    public void putPom(ResolvedGroupArtifactVersion gav, @Nullable Pom pom) {
+        pomCache.put(gav, Optional.ofNullable(pom));
+    }
+
+    @Override
+    public @Nullable Optional<MavenRepository> getNormalizedRepository(MavenRepository repository) {
+        return repositoryCache.getIfPresent(repository);
+    }
+
+    @Override
+    public void putNormalizedRepository(MavenRepository repository, MavenRepository normalized) {
+        repositoryCache.put(repository, Optional.ofNullable(normalized));
+    }
+
+    private class MavenMetadataCache implements Cache<MetadataKey, Optional<MavenMetadata>> {
+        @Override
+        public void put(MetadataKey key, Optional<MavenMetadata> value) {
+
+        }
+
+        @Override
+        public Optional<MavenMetadata> getIfPresent(MetadataKey key) {
+            return Optional.empty();
+        }
+    }
+
+    private class RepositoryCache implements Cache<MavenRepository, Optional<MavenRepository>> {
+        @Override
+        public void put(MavenRepository key, Optional<MavenRepository> value) {
+
+        }
+
+        @Override
+        public Optional<MavenRepository> getIfPresent(MavenRepository key) {
+            return Optional.empty();
+        }
+    }
+
+    private class DependencyCache implements Cache<ResolvedGroupArtifactVersion, ResolvedPom> {
+        @Override
+        public void put(ResolvedGroupArtifactVersion key, ResolvedPom value) {
+
+        }
+
+        @Override
+        public ResolvedPom getIfPresent(ResolvedGroupArtifactVersion key) {
+            return null;
+        }
+    }
+}

--- a/components/sbm-openrewrite/src/main/java/org/openrewrite/maven/FilesystemPomCache.java
+++ b/components/sbm-openrewrite/src/main/java/org/openrewrite/maven/FilesystemPomCache.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven;
+
+import org.jetbrains.annotations.NotNull;
+import org.openrewrite.maven.internal.RawPom;
+import org.openrewrite.maven.tree.Pom;
+import org.openrewrite.maven.tree.ResolvedGroupArtifactVersion;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+/**
+ * Cache implementation to store {@link Pom} objects as pom files in local Maven repository.
+ *
+ * @author Fabian Krüger
+ */
+class FilesystemPomCache implements Cache<ResolvedGroupArtifactVersion, Optional<Pom>> {
+
+    private Path cacheDir;
+
+    public FilesystemPomCache(Path cacheDir) {
+        this.cacheDir = cacheDir;
+    }
+
+    @Override
+    public void put(ResolvedGroupArtifactVersion key, Optional<Pom> optionalPom) {
+        if (optionalPom.isPresent()) {
+            Pom pom = optionalPom.get();
+            Path path = Path.of(key.getGroupId()).resolve(key.getArtifactId()).resolve(key.getVersion());
+            Path pomPath = cacheDir.resolve(path).resolve(pom.getSourcePath().getFileName());
+
+            String pomXml = new PomSerializer().serialize(pom);
+
+            Path pomDir = buildPomPath(key);
+            String pomFile = buildPomFilename(key);
+
+            if(!pomDir.toFile().exists()) {
+                if(!pomDir.toFile().exists()) {
+                    boolean dirCreated = pomDir.toFile().mkdirs();
+                    if(!dirCreated) {
+                        throw new RuntimeException("Could not create non-existent dir '%s'".formatted(pomDir));
+                    }
+                }
+                try {
+                    Files.writeString(pomDir.resolve(pomFile), pomXml);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+
+    @NotNull
+    private String buildPomFilename(ResolvedGroupArtifactVersion key) {
+        return key.getArtifactId() + "-" + key.getVersion() + (key.getDatedSnapshotVersion() != null ? key.getDatedSnapshotVersion() : "") + ".pom";
+    }
+
+    @NotNull
+    private Path buildPomPath(ResolvedGroupArtifactVersion key) {
+        return cacheDir
+                .resolve(key.getGroupId().replace(".", "/"))
+                .resolve(key.getArtifactId())
+                .resolve(key.getVersion());
+    }
+
+    @Override
+    public Optional<Pom> getIfPresent(ResolvedGroupArtifactVersion key) {
+
+        Path pomDir = buildPomPath(key);
+        String pomFilename = buildPomFilename(key);
+
+        if(!pomDir.resolve(pomFilename).toFile().exists()) {
+            return null; // Expected by OR code when no pom exists
+        }
+
+        try {
+            String pomContent = Files.readString(pomDir.resolve(pomFilename));
+            RawPom parse = RawPom.parse(new ByteArrayInputStream(pomContent.getBytes()), null);
+            Pom pom = parse.toPom(pomDir.resolve(pomFilename), null);
+            return Optional.of(pom);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+}

--- a/components/sbm-openrewrite/src/main/java/org/openrewrite/maven/PomSerializer.java
+++ b/components/sbm-openrewrite/src/main/java/org/openrewrite/maven/PomSerializer.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven;
+
+import org.jetbrains.annotations.Nullable;
+import org.openrewrite.maven.tree.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * PomSerializer allows to serialize a {@link Pom} model to its String representation.
+ *
+ * WARNING: `repository.username` and `repository.password` will be lost during serialization.
+ *
+ *
+ * @author Fabian Krüger
+ */
+public class PomSerializer {
+
+    private static final String LE = System.lineSeparator();
+    private static final String IN = "    ";
+
+    public static String serialize(Pom pom) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>").append(LE);
+        sb
+                .append("<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">")
+                .append(LE);
+        sb.append(IN).append("<modelVersion>4.0.0</modelVersion>").append(LE);
+
+        Parent parent = pom.getParent();
+        if (parent != null) {
+            sb.append(
+                e(1, "parent",
+                  e(2, "groupId", parent.getGroupId()),
+                  e(2, "artifactId", parent.getArtifactId()),
+                  e(2, "version", parent.getVersion())
+                )
+            );
+        }
+
+        sb.append(e(1, "groupId", pom.getGroupId()));
+        sb.append(e(1, "artifactId", pom.getArtifactId()));
+        sb.append(e(1, "version", pom.getVersion()));
+        sb.append(e(1, "packaging", "jar"));
+        sb.append(e(1, "name", pom.getName()));
+
+        Map<String, String> properties = pom.getProperties();
+        if (!properties.isEmpty()) {
+            sb.append(IN).append("<properties>").append(LE);
+            properties.forEach((k, v) -> {
+                sb.append(IN).append(IN).append("<" + k + ">" + v + "</" + k + ">").append(LE);
+            });
+            sb.append(IN).append("</properties>").append(LE);
+        }
+
+        List<MavenRepository> repositories = pom.getRepositories();
+        if (repositories != null && !repositories.isEmpty()) {
+            sb.append(IN).append("<repositories>").append(LE);
+            repositories.stream().forEach(r -> renderRepository(sb, r));
+            sb.append(IN).append("</repositories>").append(LE);
+        }
+
+        if(pom.getDependencies() != null && !pom.getDependencies().isEmpty()) {
+            sb.append(renderDependencies(pom.getDependencies()));
+        }
+
+        if(pom.getPlugins() != null && !pom.getPlugins().isEmpty()) {
+            sb.append(renderPlugins(pom));
+        }
+
+        if(!pom.getDependencyManagement().isEmpty()) {
+            // TODO
+        }
+        if(!pom.getLicenses().isEmpty()) {
+            // TODO
+        }
+        if(!pom.getPluginManagement().isEmpty()) {
+            // TODO
+        }
+        if(!pom.getProfiles().isEmpty()) {
+            // TODO
+        }
+//        if(pom.getRepository())
+
+
+        sb.append("</project>").append(LE);
+        String pomXml = sb.toString();
+        System.out.println(pomXml);
+        return pomXml;
+    }
+
+    private static String renderPlugins(Pom pom) {
+        String plugins = pom.getPlugins().stream().map(PomSerializer::map).collect(Collectors.joining());
+        return e2(1, "build", e2(2, "plugins", plugins));
+    }
+
+    private static String map(Plugin plugin) {
+        return e2(3, "plugin",
+                  e(4, "groupId", plugin.getGroupId()),
+                  e(4, "artifactId", plugin.getArtifactId()),
+                  e(4, "version", plugin.getVersion()),
+                  e2(4, "configuration", renderPluginConfiguration(plugin))
+           ) + LE;
+    }
+
+    @Nullable
+    private static String renderPluginConfiguration(Plugin plugin) {
+        Map<String, Object> configuration = plugin.getConfiguration("", Map.class);
+        return configuration.entrySet().stream()
+                .map(es -> PomSerializer.mapConfigProperty(5, es)).collect(Collectors.joining());
+    }
+
+    private static String mapConfigProperty(int level, Map.Entry<String, Object> e) {
+        String tag = (String) e.getKey();
+        String value;
+        if(Map.class.isInstance(e.getValue())){
+            Map<String, Object> map = (Map<String, Object>) e.getValue();
+            int finalLevel = level +1;
+//            String[] values = map.entrySet().stream().map(es -> PomSerializer.mapConfigProperty(finalLevel, es)).collect(Collectors.joining())
+            value = map.entrySet().stream().map(es -> PomSerializer.mapConfigProperty(finalLevel, es)).collect(Collectors.joining());
+            return e2(level, tag, value);
+        }
+        value = (String) e.getValue();
+        return e(level, tag, value);
+    }
+
+    private static String renderDependencies(List<Dependency> dependencies) {
+        String deps = dependencies.stream().map(PomSerializer::mapDependency).collect(Collectors.joining());
+        return e2(1, "dependencies", deps);
+    }
+
+
+    private static String mapDependency(Dependency dependency) {
+        return e2(2, "dependency",
+                   e(3, "groupId", dependency.getGroupId()),
+                   e(3, "artifactId", dependency.getArtifactId()),
+                   e(3, "version", dependency.getVersion()),
+                   e(3, "optional", dependency.getOptional()),
+                   e(3, "type", dependency.getType()),
+                   e(3, "scope", dependency.getScope())
+                ) + LE;
+    }
+
+    private static String e(int level, String tag, String... value) {
+        String values = Arrays
+                .asList(value)
+                .stream()
+                .collect(Collectors.joining());
+        return IN.repeat(level) + "<%s>%s%s%s</%s>%s".formatted(tag, LE, values, IN, tag, LE);
+    }
+
+    private static String e(int level, String tag, String value) {
+        if(value == null) {
+            return "";
+        }
+        return IN.repeat(level) + "<%s>%s</%s>%s".formatted(tag, value, tag, LE);
+    }
+
+    private static String e2(int i, String tag, String value) {
+        return IN.repeat(i) + "<" + tag + ">" + LE +  value  + IN.repeat(i) + "</" + tag + ">" + LE;
+    }
+
+    private static String e2(int i, String tag, String... value) {
+        String values = Arrays
+                .asList(value)
+                .stream()
+                .collect(Collectors.joining());
+        return IN.repeat(i) + "<" + tag + ">" + LE +  values + IN.repeat(i) + "</" + tag + ">";
+    }
+
+
+    private static void renderRepository(StringBuilder sb, MavenRepository r) {
+        sb.append(IN).append(IN).append("<repository>").append(LE);
+        sb.append(IN).append(IN).append(IN).append("<id>").append(r.getId()).append("</id>").append(LE);
+        sb.append(IN).append(IN).append(IN).append("<uri>").append(r.getUri()).append("</uri>").append(LE);
+        if(r.getUsername() != null) {
+            e(3, "username", r.getUsername());
+        }
+        if (r.getPassword() != null) {
+            sb
+                    .append(IN)
+                    .append(IN)
+                    .append(IN)
+                    .append("<password>")
+                    .append(r.getPassword())
+                    .append("</password>")
+                    .append(LE);
+        }
+        if (r.getReleases() != null) {
+            sb
+                    .append(IN)
+                    .append(IN)
+                    .append(IN)
+                    .append("<releases><enabled>")
+                    .append(r.getReleases())
+                    .append("</enabled></releases>")
+                    .append(LE);
+        }
+        if (r.getSnapshots() != null) {
+            sb
+                    .append(IN)
+                    .append(IN)
+                    .append(IN)
+                    .append("<snapshots><enabled>")
+                    .append(r.getSnapshots())
+                    .append("</enabled></snapshots>")
+                    .append(LE);
+        }
+        if(r.isKnownToExist()) {
+
+        }
+        sb.append(IN).append(IN).append("</repository>").append(LE);
+    }
+}

--- a/components/sbm-openrewrite/src/test/java/org/openrewrite/maven/FilesystemPomCacheTest.java
+++ b/components/sbm-openrewrite/src/test/java/org/openrewrite/maven/FilesystemPomCacheTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.maven.internal.RawPom;
+import org.openrewrite.maven.tree.MavenRepository;
+import org.openrewrite.maven.tree.Pom;
+import org.openrewrite.maven.tree.ResolvedGroupArtifactVersion;
+
+import java.io.ByteArrayInputStream;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Fabian Krüger
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class FilesystemPomCacheTest {
+
+    private static final String POM = """
+                    <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+                      <modelVersion>4.0.0</modelVersion>
+                      <parent>
+                        <groupId>org.apache.activemq</groupId>
+                        <artifactId>activemq-parent</artifactId>
+                        <version>5.16.0</version>
+                      </parent>
+                      <artifactId>activemq-jdbc-store</artifactId>
+                      <packaging>jar</packaging>
+                      <name>ActiveMQ :: JDBC Store</name>
+                      <description>The ActiveMQ JDBC Store Implementation</description>
+                      <properties>
+                        <surefire.argLine>-Xmx512M</surefire.argLine>
+                      </properties>
+                      <dependencies>
+                        <dependency>
+                          <groupId>org.apache.activemq</groupId>
+                          <artifactId>activemq-broker</artifactId>
+                        </dependency>
+                        <dependency>
+                          <groupId>org.apache.derby</groupId>
+                          <artifactId>derby</artifactId>
+                          <optional>true</optional>
+                        </dependency>
+                        <dependency>
+                          <groupId>${project.groupId}</groupId>
+                          <artifactId>activeio-core</artifactId>
+                          <optional>true</optional>
+                        </dependency>
+                        <dependency>
+                          <groupId>junit</groupId>
+                          <artifactId>junit</artifactId>
+                          <scope>test</scope>
+                        </dependency>
+                        <dependency>
+                          <groupId>org.mockito</groupId>
+                          <artifactId>mockito-core</artifactId>
+                          <scope>test</scope>
+                        </dependency>
+                        <dependency>
+                          <groupId>org.apache.activemq</groupId>
+                          <artifactId>activemq-broker</artifactId>
+                          <type>test-jar</type>
+                          <scope>test</scope>
+                        </dependency>
+                        <dependency>
+                          <groupId>org.slf4j</groupId>
+                          <artifactId>slf4j-log4j12</artifactId>
+                          <scope>test</scope>
+                        </dependency>
+                      </dependencies>
+                      <reporting>
+                        <plugins>
+                          <plugin>
+                            <groupId>org.codehaus.mojo</groupId>
+                            <artifactId>findbugs-maven-plugin</artifactId>
+                            <version>${findbugs-maven-plugin-version}</version>
+                            <configuration>
+                              <threshold>Normal</threshold>
+                              <effort>Default</effort>
+                            </configuration>
+                          </plugin>
+                        </plugins>
+                      </reporting>
+                      <build>
+                        <plugins>
+                          <plugin>
+                            <artifactId>maven-surefire-plugin</artifactId>
+                            <configuration>
+                                <forkCount>1</forkCount>
+                                <reuseForks>false</reuseForks>
+                              <argLine>${surefire.argLine}</argLine>
+                              <runOrder>alphabetical</runOrder>
+                              <systemProperties>
+                                <property>
+                                  <name>org.apache.activemq.default.directory.prefix</name>
+                                  <value>target/</value>
+                                </property>
+                                <!-- Uncomment the following if you want to configure custom logging (using src/test/resources/log4j.properties)
+                                     while running mvn:test
+                                     Note: if you want to see log messages on the console window remove
+                                           "redirectTestOutputToFile" from the parent pom
+                                -->
+                                <!--
+                                <property>
+                                  <name>log4j.configuration</name>
+                                  <value>file:target/test-classes/log4j.properties</value>
+                                </property>
+                                -->
+                              </systemProperties>
+                              <includes>
+                                <include>**/*Test.*</include>
+                              </includes>
+                            </configuration>
+                          </plugin>
+                        </plugins>
+                      </build>
+                    </project>
+                """;
+    private ResolvedGroupArtifactVersion resolvedGav;
+    private MavenRepository repo = new MavenRepository("Maven", "https://repo.maven.apache.org/maven2/", null, null, false, null, null, false);
+    private RawPom rawPom = RawPom.parse(new ByteArrayInputStream(POM.getBytes()), null);
+    private FilesystemPomCache sut;
+    private Pom pomModel;
+    @TempDir
+    static Path cacheDir;
+
+    @BeforeEach
+    void beforeAll() {
+        resolvedGav = new ResolvedGroupArtifactVersion(repo.getUri(), "org.apache.activemq", "activemq-jdbc-store", "5.16.0", null);
+        pomModel = rawPom.toPom(cacheDir, repo).withGav(resolvedGav);
+        sut = new FilesystemPomCache(cacheDir);
+    }
+
+    @Test
+    @Order(1)
+    void storeNonExistentPom() {
+        assertThat(cacheDir.toFile().listFiles()).isEmpty();
+
+        sut.put(resolvedGav, Optional.of(pomModel));
+
+        assertThat(cacheDir.toFile().listFiles()).hasSize(1);
+    }
+
+    @Test
+    @Order(2)
+    void retrievePreviouslyPutPom() {
+        assertThat(cacheDir.toFile().listFiles()).hasSize(1);
+
+        Optional<Pom> returnedPom = sut.getIfPresent(resolvedGav);
+
+        assertThat(returnedPom).isPresent();
+        Pom pom = returnedPom.get();
+        assertThat(pom.getSourcePath()).isEqualTo(cacheDir.resolve("org/apache/activemq/activemq-jdbc-store/5.16.0/activemq-jdbc-store-5.16.0.pom"));
+
+        eq(pom.getParent().getGroupId(), "org.apache.activemq");
+        eq(pom.getParent().getVersion(), "5.16.0");
+        eq(pom.getArtifactId(),  "activemq-parent");
+
+        eq(pom.getGroupId(), "org.apache.activemq");
+        eq(pom.getArtifactId(), "activemq-jdbc-store");
+    }
+
+    private void eq(String given, String expected) {
+        assertThat(given).isEqualTo(expected);
+    }
+
+}

--- a/components/sbm-openrewrite/src/test/java/org/openrewrite/maven/PomSerializerTest.java
+++ b/components/sbm-openrewrite/src/test/java/org/openrewrite/maven/PomSerializerTest.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.maven.internal.RawPom;
+import org.openrewrite.maven.tree.Pom;
+
+import java.io.ByteArrayInputStream;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Fabian Krüger
+ */
+class PomSerializerTest {
+
+    private static final String POM = """
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>org.apache.activemq</groupId>
+                    <artifactId>activemq-parent</artifactId>
+                    <version>5.16.0</version>
+                  </parent>
+                  <artifactId>activemq-jdbc-store</artifactId>
+                  <packaging>jar</packaging>
+                  <name>ActiveMQ :: JDBC Store</name>
+                  <description>The ActiveMQ JDBC Store Implementation</description>
+                  <properties>
+                    <surefire.argLine>-Xmx512M</surefire.argLine>
+                    <foo>bar</foo>
+                  </properties>
+                  <repositories>
+                      <repository>
+                          <id>jitpack.io</id>
+                          <url>https://jitpack.io</url>
+                      </repository>
+                      <repository>
+                          <id>jcenter</id>
+                          <name>jcenter</name>
+                          <url>https://jcenter.bintray.com</url>
+                          <username>aUser</username>
+                          <password>Z-je34</password>
+                      </repository>
+                      <repository>
+                          <id>mavencentral</id>
+                          <name>mavencentral</name>
+                          <url>https://repo.maven.apache.org/maven2</url>
+                      </repository>
+                      <repository>
+                          <id>repository.spring.milestone</id>
+                          <name>Spring Milestone Repository</name>
+                          <url>https://repo.spring.io/milestone</url>
+                          <releases>
+                            <enabled>false</enabled>
+                          </releases>
+                      </repository>
+                  </repositories>
+                  <dependencies>
+                    <dependency>
+                      <groupId>${project.groupId}</groupId>
+                      <artifactId>activeio-core</artifactId>
+                      <optional>true</optional>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.apache.activemq</groupId>
+                      <artifactId>activemq-broker</artifactId>
+                      <type>test-jar</type>
+                      <scope>test</scope>
+                    </dependency>
+                  </dependencies>
+                  <reporting>
+                    <plugins>
+                      <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>findbugs-maven-plugin</artifactId>
+                        <version>${findbugs-maven-plugin-version}</version>
+                        <configuration>
+                          <threshold>Normal</threshold>
+                          <effort>Default</effort>
+                        </configuration>
+                      </plugin>
+                    </plugins>
+                  </reporting>
+                  <build>
+                    <plugins>
+                      <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <forkCount>1</forkCount>
+                            <reuseForks>false</reuseForks>
+                          <argLine>${surefire.argLine}</argLine>
+                          <runOrder>alphabetical</runOrder>
+                          <systemProperties>
+                            <property>
+                              <name>org.apache.activemq.default.directory.prefix</name>
+                              <value>target/</value>
+                            </property>
+                            <!-- Uncomment the following if you want to configure custom logging (using src/test/resources/log4j.properties)
+                                 while running mvn:test
+                                 Note: if you want to see log messages on the console window remove
+                                       "redirectTestOutputToFile" from the parent pom
+                            -->
+                            <!--
+                            <property>
+                              <name>log4j.configuration</name>
+                              <value>file:target/test-classes/log4j.properties</value>
+                            </property>
+                            -->
+                          </systemProperties>
+                          <includes>
+                            <include>**/*Test.*</include>
+                          </includes>
+                        </configuration>
+                      </plugin>
+                    </plugins>
+                  </build>
+                </project>
+            """;
+
+    @Test
+    void serialize() {
+        RawPom rawPom = RawPom.parse(new ByteArrayInputStream(POM.getBytes()), null);
+        Pom pom = rawPom.toPom(Path.of("path/to/pom"), null);
+
+        assertThat(pom.getSourcePath()).isEqualTo(Path.of("path/to/pom"));
+
+        String p = PomSerializer.serialize(pom);
+
+        assertThat(p)
+                .isEqualTo(
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+                        <modelVersion>4.0.0</modelVersion>
+                        <parent>
+                            <groupId>org.apache.activemq</groupId>
+                            <artifactId>activemq-parent</artifactId>
+                            <version>5.16.0</version>
+                        </parent>
+                        <groupId>org.apache.activemq</groupId>
+                        <artifactId>activemq-jdbc-store</artifactId>
+                        <version>5.16.0</version>
+                        <packaging>jar</packaging>
+                        <name>ActiveMQ :: JDBC Store</name>
+                        <properties>
+                            <surefire.argLine>-Xmx512M</surefire.argLine>
+                            <foo>bar</foo>
+                        </properties>
+                        <repositories>
+                            <repository>
+                                <id>jitpack.io</id>
+                                <uri>https://jitpack.io</uri>
+                            </repository>
+                            <repository>
+                                <id>jcenter</id>
+                                <uri>https://jcenter.bintray.com</uri>
+                            </repository>
+                            <repository>
+                                <id>mavencentral</id>
+                                <uri>https://repo.maven.apache.org/maven2</uri>
+                            </repository>
+                            <repository>
+                                <id>repository.spring.milestone</id>
+                                <uri>https://repo.spring.io/milestone</uri>
+                            </repository>
+                        </repositories>                        
+                        <dependencies>
+                            <dependency>
+                                <groupId>${project.groupId}</groupId>
+                                <artifactId>activeio-core</artifactId>
+                                <optional>true</optional>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.apache.activemq</groupId>
+                                <artifactId>activemq-broker</artifactId>
+                                <type>test-jar</type>
+                                <scope>test</scope>
+                            </dependency>
+                        </dependencies>
+                        <build>
+                            <plugins>
+                                <plugin>
+                                    <artifactId>maven-surefire-plugin</artifactId>
+                                    <configuration>
+                                        <forkCount>1</forkCount>
+                                        <reuseForks>false</reuseForks>
+                                        <argLine>${surefire.argLine}</argLine>
+                                        <runOrder>alphabetical</runOrder>
+                                        <systemProperties>
+                                            <property>
+                                                <name>org.apache.activemq.default.directory.prefix</name>
+                                                <value>target/</value>
+                                            </property>
+                                        </systemProperties>
+                                        <includes>
+                                            <include>**/*Test.*</include>
+                                        </includes>
+                                    </configuration>
+                                </plugin>
+                            </plugins>
+                        </build>
+                    </project>
+                    """
+                );
+/*
+        eq(pom.getParent().getGroupId(), "org.apache.activemq");
+        eq(pom.getParent().getVersion(), "5.16.0");
+        eq(pom.getParent().getArtifactId(),  "activemq-parent");
+
+        eq(pom.getGroupId(), "org.apache.activemq");
+        eq(pom.getArtifactId(), "activemq-jdbc-store");
+        eq(pom.getVersion(), "5.16.0");
+        eq(pom.getPackaging(), "pom");
+        eq(pom.getName(), "ActiveMQ :: JDBC Store");
+        assertThat(pom.getProperties()).containsAllEntriesOf(Map.of(
+                "surefire.argLine", "-Xmx512M",
+                "foo", "bar"
+        ));
+
+ */
+    }
+
+    private void eq(String given, String expected) {
+        assertThat(given).isEqualTo(expected);
+    }
+}

--- a/components/sbm-openrewrite/src/test/java/org/springframework/sbm/support/openrewrite/api/UpgradeDependencyVersionTest.java
+++ b/components/sbm-openrewrite/src/test/java/org/springframework/sbm/support/openrewrite/api/UpgradeDependencyVersionTest.java
@@ -24,6 +24,8 @@ import org.openrewrite.maven.UpgradeDependencyVersion;
 import org.openrewrite.xml.tree.Xml;
 
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -200,18 +202,16 @@ public class UpgradeDependencyVersionTest {
     }
 
     @Test
-    void testUpgradeDependency_nullVersion() {
+    void testUpgradeDependency_nullVersion() throws InterruptedException {
         String groupId = "org.springframework.boot";
         String artifactId = "spring-boot-starter-test";
         String version = null;
         UpgradeDependencyVersion sut = new UpgradeDependencyVersion(groupId, artifactId, version, null, false, List.of());
 
-        AtomicBoolean exceptionThrown = new AtomicBoolean(false);
-        RecipeRun results = sut.run(mavens, new InMemoryExecutionContext((e) -> {
-            e.printStackTrace();
-            exceptionThrown.set(true);
+        CountDownLatch thrown = new CountDownLatch(1);
+        sut.run(mavens, new InMemoryExecutionContext((e) -> {
+            thrown.countDown();
         }));
-//        assertThat(exceptionThrown).isTrue();
-
+        assertThat(thrown.await(50, TimeUnit.MILLISECONDS)).isTrue();
     }
 }


### PR DESCRIPTION
The experiment surfaced problems with the attempt to use local Maven repository dir as cache store for pom files downloaded by OpenRewrite's `MavenPomDownloader`.

The cache API used by `MavenPomDownloader` accepts only `Pom` instances.
The `Pom` class represents the model and contains additional information (e.g. `repository.password`) which can't be seriaiized to a pom file adhering to the [xsd](https://maven.apache.org/xsd/maven-4.0.0.xsd).

The PR brings an initial implementation of a `PomSerializer` but the above problem currently does not allow for a stable implementation. 