### PR TITLE
Make migrate-annotated-servlets-recipe only applicable for classes annotated with @WebServlet

### DIFF
--- a/components/sbm-recipes-jee-to-boot/src/main/resources/recipes/migrate-annotated-servlets.yaml
+++ b/components/sbm-recipes-jee-to-boot/src/main/resources/recipes/migrate-annotated-servlets.yaml
@@ -3,8 +3,8 @@
   order: 70
   condition:
     description: Any class has import starting with javax.servlet
-    type: org.springframework.sbm.java.migration.conditions.HasImportStartingWith
-    value: javax.servlet
+    type: org.springframework.sbm.java.migration.conditions.HasTypeAnnotation
+    annotation: javax.servlet.annotation.WebServlet
   actions:
     - type: org.springframework.sbm.build.migration.actions.AddDependencies
       condition:


### PR DESCRIPTION
The condition for `migrate-annotated-servlets-recipe` has been changed to make the recipe only applicable when classes annotated with @WebServlet exist