### PR TITLE
fix: Removed dependency to Junit4

### DIFF
--- a/applications/spring-shell/pom.xml
+++ b/applications/spring-shell/pom.xml
@@ -83,6 +83,12 @@
             <artifactId>testcontainers</artifactId>
             <version>${testcontainers.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.rabbitmq</groupId>

--- a/applications/spring-shell/src/test/java/org/junit/rules/ExternalResource.java
+++ b/applications/spring-shell/src/test/java/org/junit/rules/ExternalResource.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.junit.rules;
+
+/**
+ * "Fake" class used as a replacement for Junit4-dependent classes.
+ * See more at: <a href="https://github.com/testcontainers/testcontainers-java/issues/970">
+ * GenericContainer run from Jupiter tests shouldn't require JUnit 4.x library on runtime classpath
+ * </a>.
+ */
+public class ExternalResource {
+}

--- a/applications/spring-shell/src/test/java/org/junit/rules/Statement.java
+++ b/applications/spring-shell/src/test/java/org/junit/rules/Statement.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.junit.rules;
+
+/**
+ * "Fake" class used as a replacement for Junit4-dependent classes.
+ * See more at: <a href="https://github.com/testcontainers/testcontainers-java/issues/970">
+ * GenericContainer run from Jupiter tests shouldn't require JUnit 4.x library on runtime classpath
+ * </a>.
+ */
+@SuppressWarnings("unused")
+public class Statement {
+}

--- a/applications/spring-shell/src/test/java/org/junit/rules/TestRule.java
+++ b/applications/spring-shell/src/test/java/org/junit/rules/TestRule.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.junit.rules;
+
+/**
+ * "Fake" class used as a replacement for Junit4-dependent classes.
+ * See more at: <a href="https://github.com/testcontainers/testcontainers-java/issues/970">
+ * GenericContainer run from Jupiter tests shouldn't require JUnit 4.x library on runtime classpath
+ * </a>.
+ */
+@SuppressWarnings("unused")
+public interface TestRule {
+}

--- a/applications/spring-shell/src/test/java/org/springframework/sbm/IntegrationTestBaseClass.java
+++ b/applications/spring-shell/src/test/java/org/springframework/sbm/IntegrationTestBaseClass.java
@@ -59,7 +59,7 @@ import java.util.stream.Collectors;
 
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Base class to be extended by integrationTests.
@@ -236,16 +236,16 @@ public abstract class IntegrationTestBaseClass {
                 CommandLineException executionException = invocationResult.getExecutionException();
                 int exitCode = invocationResult.getExitCode();
                 if (executionException != null) {
-                    Assert.fail("Maven build 'mvn " + g
+                    fail("Maven build 'mvn " + g
                             + " " + pomXml + " "
                             + "' failed with Exception: " + executionException.getMessage());
                 }
                 if (exitCode != 0) {
-                    Assert.fail("Maven build 'mvn " + g
+                    fail("Maven build 'mvn " + g
                             + "' failed with exitCode: " + exitCode);
                 }
             } catch (MavenInvocationException e) {
-                Assert.fail("Maven build 'mvn " + g
+                fail("Maven build 'mvn " + g
                         + " " + pomXml + " "
                         + "' failed with Exception: " + e.getMessage());
                 e.printStackTrace();

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,12 @@
                 <artifactId>testcontainers</artifactId>
                 <version>${testcontainers.version}</version>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.shared</groupId>


### PR DESCRIPTION
Addresses https://github.com/spring-projects-experimental/spring-boot-migrator/issues/775.

Workaround idea for excluding junit4 from testcontainers dependency taken from https://github.com/testcontainers/testcontainers-java/issues/970 

Additionally adjusted IntegrationTestBaseClass to use junit5 fail assertion

![obraz](https://user-images.githubusercontent.com/18751715/234805178-4618265c-83f9-45b7-8679-61748932de17.png)
