### PR TITLE
fix: Adding a managed Maven dependency throws exception if it exists in same or higher version

### DIFF
--- a/applications/spring-shell/src/test/java/org/springframework/sbm/IntegrationTestBaseClass.java
+++ b/applications/spring-shell/src/test/java/org/springframework/sbm/IntegrationTestBaseClass.java
@@ -178,23 +178,23 @@ public abstract class IntegrationTestBaseClass {
      * @param applicableRecipes
      */
     protected void assertApplicableRecipesContain(String... applicableRecipes) {
-        List<String> recipeNames = getRecipeNames();
+        List<String> recipeNames = getApplicableRecipeNames();
         assertThat(recipeNames).contains(applicableRecipes);
     }
 
     @NotNull
-    private List<String> getRecipeNames() {
+    protected List<String> getApplicableRecipeNames() {
         return applicableRecipeListCommand.execute(projectContextHolder.getProjectContext()).stream()
                 .map(r -> r.getName()).collect(Collectors.toList());
     }
 
     protected void assertRecipeApplicable(String recipeName) {
-        List<String> recipeNames = getRecipeNames();
+        List<String> recipeNames = getApplicableRecipeNames();
         assertThat(recipeNames).contains(recipeName);
     }
 
     protected void assertRecipeNotApplicable(String recipeName) {
-        List<String> recipeNames = getRecipeNames();
+        List<String> recipeNames = getApplicableRecipeNames();
         assertThat(recipeNames).doesNotContain(recipeName);
     }
 

--- a/components/sbm-core/src/main/java/org/springframework/sbm/build/migration/actions/AddMavenDependencyManagementAction.java
+++ b/components/sbm-core/src/main/java/org/springframework/sbm/build/migration/actions/AddMavenDependencyManagementAction.java
@@ -15,12 +15,15 @@
  */
 package org.springframework.sbm.build.migration.actions;
 
-import org.springframework.sbm.build.api.Module;
+import org.apache.maven.artifact.versioning.ComparableVersion;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.sbm.build.api.BuildFile;
 import org.springframework.sbm.build.api.Dependency;
 import org.springframework.sbm.engine.recipe.AbstractAction;
 import org.springframework.sbm.engine.context.ProjectContext;
 import lombok.Setter;
+
+import java.util.Optional;
 
 @Setter
 public class AddMavenDependencyManagementAction extends AbstractAction {
@@ -33,6 +36,8 @@ public class AddMavenDependencyManagementAction extends AbstractAction {
 
     @Override
     public void apply(ProjectContext context) {
+        verifyNoConflictingManagedDependencyExists(context);
+
         Dependency dependency = Dependency.builder()
                 .groupId(groupId)
                 .artifactId(artifactId)
@@ -40,7 +45,49 @@ public class AddMavenDependencyManagementAction extends AbstractAction {
                 .scope(scope)
                 .type(dependencyType)
                 .build();
+        BuildFile rootBuildFile = context.getApplicationModules().getRootModule().getBuildFile();
+        rootBuildFile.addToDependencyManagement(dependency);
+    }
 
-        context.getApplicationModules().getRootModule().getBuildFile().addToDependencyManagement(dependency);
+    @NotNull
+    private void verifyNoConflictingManagedDependencyExists(ProjectContext context) {
+        BuildFile rootBuildFile = context.getApplicationModules().getRootModule().getBuildFile();
+        Optional<Dependency> managedSpringDep = rootBuildFile
+                .getRequestedDependencyManagement()
+                .stream()
+                .filter(this::matchingDependencyManagementSection)
+                .findFirst();
+
+        if(managedSpringDep.isPresent()) {
+            Dependency managedDep = managedSpringDep.get();
+            int comparisonResult = compareVersions(this.version, managedDep.getVersion());
+            if(managedDependencyHasSameVersion(comparisonResult) || managedDependencyHasHigherVersion(comparisonResult)) {
+                String message = String.format(
+                        "Failed to add a managed dependency %s with version %s. This managed dependency already exists in %s in version %s.",
+                        this.groupId + ":" + this.artifactId,
+                        this.version,
+                        rootBuildFile.getAbsolutePath(),
+                        managedDep.getVersion()
+                );
+                throw new IllegalStateException(message);
+            }
+        }
+    }
+
+    private boolean managedDependencyHasSameVersion(int comparisonResult) {
+        return comparisonResult == 0;
+    }
+
+    private boolean managedDependencyHasHigherVersion(int comparisonResult) {
+        return comparisonResult == -1;
+    }
+
+    private int compareVersions(String newVersion, String existingVersion) {
+        return new ComparableVersion(newVersion).compareTo(new ComparableVersion(existingVersion));
+    }
+
+    private boolean matchingDependencyManagementSection(Dependency dependency) {
+        return dependency.getGroupId().equals(groupId) &&
+                dependency.getArtifactId().equals(artifactId);
     }
 }

--- a/components/sbm-core/src/main/java/org/springframework/sbm/build/migration/conditions/NoMoreRecentManagedDependencyExists.java
+++ b/components/sbm-core/src/main/java/org/springframework/sbm/build/migration/conditions/NoMoreRecentManagedDependencyExists.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sbm.build.migration.conditions;
+
+import lombok.Setter;
+import org.apache.maven.artifact.versioning.ComparableVersion;
+import org.springframework.sbm.build.api.BuildFile;
+import org.springframework.sbm.build.api.Dependency;
+import org.springframework.sbm.build.api.Module;
+import org.springframework.sbm.engine.context.ProjectContext;
+import org.springframework.sbm.engine.recipe.Condition;
+
+import java.util.List;
+
+/**
+ * @author Fabian Krüger
+ */
+@Setter
+public class NoMoreRecentManagedDependencyExists implements Condition {
+
+    private String groupId;
+    private String artifactId;
+    private String version;
+
+
+    @Override
+    public String getDescription() {
+        return "Check that no more recent managed dependency exists";
+    }
+
+    @Override
+    public boolean evaluate(ProjectContext context) {
+        return context.getApplicationModules().stream().map(Module::getBuildFile)
+                .noneMatch(this::hasConflictingManagedDependency);
+    }
+
+    private boolean hasConflictingManagedDependency(BuildFile buildFile) {
+        List<Dependency> requestedDependencyManagement = buildFile.getRequestedDependencyManagement();
+        if(requestedDependencyManagement == null || requestedDependencyManagement.isEmpty()) {
+            return false;
+        }
+        return buildFile.getRequestedDependencyManagement().stream()
+                .anyMatch(this::isConflictingDEpendency);
+    }
+
+    private boolean isConflictingDEpendency(Dependency dependency) {
+        boolean matchingGA = groupId.equals(dependency.getGroupId()) &&
+                artifactId.equals(dependency.getArtifactId());
+
+        if(matchingGA) {
+            return hasConflictingVersion(dependency);
+        } else {
+            return false;
+        }
+    }
+
+    private boolean hasConflictingVersion(Dependency dependency) {
+        int comparisonResult = compareVersions(version, dependency.getVersion());
+        return managedDependencyHasHigherVersion(comparisonResult) || managedDependencyHasSameVersion(comparisonResult);
+    }
+
+    private boolean managedDependencyHasSameVersion(int comparisonResult) {
+        return comparisonResult == 0;
+    }
+
+    private boolean managedDependencyHasHigherVersion(int comparisonResult) {
+        return comparisonResult == -1;
+    }
+
+    private int compareVersions(String newVersion, String existingVersion) {
+        return new ComparableVersion(newVersion).compareTo(new ComparableVersion(existingVersion));
+    }
+}

--- a/components/sbm-core/src/main/java/org/springframework/sbm/java/exceptions/UnresolvedTypeException.java
+++ b/components/sbm-core/src/main/java/org/springframework/sbm/java/exceptions/UnresolvedTypeException.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.sbm.java.exceptions;
 
 public class UnresolvedTypeException extends RuntimeException {

--- a/components/sbm-core/src/main/java/org/springframework/sbm/java/migration/recipes/openrewrite/ReplaceConstantWithAnotherConstant.java
+++ b/components/sbm-core/src/main/java/org/springframework/sbm/java/migration/recipes/openrewrite/ReplaceConstantWithAnotherConstant.java
@@ -1,12 +1,12 @@
 /*
- * Copyright 2023 the original author or authors.
- * <p>
+ * Copyright 2021 - 2022 the original author or authors.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * https://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/components/sbm-core/src/test/java/org/springframework/sbm/build/migration/actions/AddMavenDependencyManagementActionTest.java
+++ b/components/sbm-core/src/test/java/org/springframework/sbm/build/migration/actions/AddMavenDependencyManagementActionTest.java
@@ -23,6 +23,7 @@ import org.springframework.sbm.project.resource.TestProjectContext;
 import org.springframework.sbm.testhelper.common.utils.TestDiff;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class AddMavenDependencyManagementActionTest {
 
@@ -204,5 +205,61 @@ class AddMavenDependencyManagementActionTest {
         assertThat(buildFile.print())
                 .as(TestDiff.of(buildFile.print(), expected))
                 .isEqualTo(expected);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenSameManagedDependencyExistsWithHigherVersion() {
+        String versionInPom = "2.7.5";
+        String versionInRecipe = "2.7.4";
+        testAddMavenDependencyManagementAction(versionInPom, versionInRecipe);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenSameManagedDependencyExistsWithSameVersion() {
+        String versionInPom = "2.7.5";
+        String versionInRecipe = "2.7.5";
+        testAddMavenDependencyManagementAction(versionInPom, versionInRecipe);
+    }
+
+    private void testAddMavenDependencyManagementAction(String versionInPom, String versionInRecipe) {
+        String pom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                	<modelVersion>4.0.0</modelVersion>
+                	<groupId>com.example</groupId>
+                	<artifactId>demo</artifactId>
+                	<version>0.0.1-SNAPSHOT</version>
+                	<name>demo</name>
+                	<description>Demo project for Spring Boot</description>
+                	<properties>
+                		<java.version>17</java.version>
+                	</properties>
+                	<dependencyManagement>
+                		<dependencies>
+                			<dependency>
+                				<groupId>org.springframework.boot</groupId>
+                				<artifactId>spring-boot-dependencies</artifactId>
+                				<version>%s</version>
+                				<type>pom</type>
+                				<scope>import</scope>
+                			</dependency>
+                		</dependencies>
+                	</dependencyManagement>
+                </project>
+                """.formatted(versionInPom);
+
+        ProjectContext projectContext = TestProjectContext.buildProjectContext().withMavenRootBuildFileSource(pom).build();
+
+        AddMavenDependencyManagementAction sut = new AddMavenDependencyManagementAction();
+        sut.setGroupId("org.springframework.boot");
+        sut.setArtifactId("spring-boot-dependencies");
+
+        sut.setVersion(versionInRecipe);
+
+        assertThrows(IllegalStateException.class, () -> {
+            sut.apply(projectContext);
+        }).getMessage().equals("Failed to add a managed dependency org.springframework.boot:spring-boot-dependencies with version "+ versionInRecipe +". " +
+                               "This managed dependency already exists in " + projectContext.getApplicationModules().getRootModule().getBuildFile().getAbsolutePath().toString() + " in version "+versionInPom+".");
     }
 }

--- a/components/sbm-core/src/test/java/org/springframework/sbm/build/migration/conditions/NoMoreRecentManagedDependencyExistsTest.java
+++ b/components/sbm-core/src/test/java/org/springframework/sbm/build/migration/conditions/NoMoreRecentManagedDependencyExistsTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2021 - 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sbm.build.migration.conditions;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.sbm.engine.context.ProjectContext;
+import org.springframework.sbm.project.resource.TestProjectContext;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+/**
+ * @author Fabian Krüger
+ */
+class NoMoreRecentManagedDependencyExistsTest {
+
+    @Test
+    void shouldReturnFalseForManagedDependencyWithSameVersion() {
+        ProjectContext projectContext = createProjectContextWithPom("2.7.3");
+
+        NoMoreRecentManagedDependencyExists sut = new NoMoreRecentManagedDependencyExists();
+        sut.setGroupId("org.springframework.boot");
+        sut.setArtifactId("spring-boot-dependencies");
+        sut.setVersion("2.7.3");
+
+        boolean result = sut.evaluate(projectContext);
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalseForManagedDependencyWithMoreRecentVersion() {
+        ProjectContext projectContext = createProjectContextWithPom("2.7.4");
+
+        NoMoreRecentManagedDependencyExists sut = new NoMoreRecentManagedDependencyExists();
+        sut.setGroupId("org.springframework.boot");
+        sut.setArtifactId("spring-boot-dependencies");
+        sut.setVersion("2.7.3");
+
+        boolean result = sut.evaluate(projectContext);
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void shouldReturnTrueForManagedDependencyWithLowerVersion() {
+        ProjectContext projectContext = createProjectContextWithPom("2.7.2");
+
+        NoMoreRecentManagedDependencyExists sut = new NoMoreRecentManagedDependencyExists();
+        sut.setGroupId("org.springframework.boot");
+        sut.setArtifactId("spring-boot-dependencies");
+        sut.setVersion("2.7.3");
+
+        boolean result = sut.evaluate(projectContext);
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void shouldReturnTrueForManagedDependencyWithDifferentGroupId() {
+        ProjectContext projectContext = createProjectContextWithPom("2.7.3");
+
+        NoMoreRecentManagedDependencyExists sut = new NoMoreRecentManagedDependencyExists();
+        sut.setGroupId("org.springframework.different");
+        sut.setArtifactId("spring-boot-dependencies");
+        sut.setVersion("2.7.2");
+
+        boolean result = sut.evaluate(projectContext);
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void shouldReturnTrueForManagedDependencyWithDifferentArtifactId() {
+        ProjectContext projectContext = createProjectContextWithPom("2.7.3");
+
+        NoMoreRecentManagedDependencyExists sut = new NoMoreRecentManagedDependencyExists();
+        sut.setGroupId("org.springframework.boot");
+        sut.setArtifactId("spring-boot-different");
+        sut.setVersion("2.7.2");
+
+        boolean result = sut.evaluate(projectContext);
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void shouldReturnTrueWhenNoManagedDependencyExists() {
+        String pom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                	<modelVersion>4.0.0</modelVersion>
+                	<groupId>com.example</groupId>
+                	<artifactId>demo</artifactId>
+                	<version>0.0.1-SNAPSHOT</version>
+                	<name>demo</name>
+                	<description>Demo project for Spring Boot</description>
+                	<properties>
+                		<java.version>17</java.version>
+                	</properties>
+                </project>
+                """;
+
+        ProjectContext projectContext = TestProjectContext.buildProjectContext().withMavenRootBuildFileSource(pom).build();
+
+        NoMoreRecentManagedDependencyExists sut = new NoMoreRecentManagedDependencyExists();
+        sut.setGroupId("org.springframework.boot");
+        sut.setArtifactId("spring-boot-different");
+        sut.setVersion("2.7.2");
+
+        boolean result = sut.evaluate(projectContext);
+        assertThat(result).isTrue();
+    }
+
+
+    private ProjectContext createProjectContextWithPom(String version) {
+        return TestProjectContext.buildProjectContext().withMavenRootBuildFileSource("""
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                	<modelVersion>4.0.0</modelVersion>
+                	<groupId>com.example</groupId>
+                	<artifactId>demo</artifactId>
+                	<version>0.0.1-SNAPSHOT</version>
+                	<name>demo</name>
+                	<description>Demo project for Spring Boot</description>
+                	<properties>
+                		<java.version>17</java.version>
+                	</properties>
+                	<dependencyManagement>
+                		<dependencies>
+                			<dependency>
+                				<groupId>org.springframework.boot</groupId>
+                				<artifactId>spring-boot-dependencies</artifactId>
+                				<version>%s</version>
+                				<type>pom</type>
+                				<scope>import</scope>
+                			</dependency>
+                		</dependencies>
+                	</dependencyManagement>
+                </project>
+                """.formatted(version))
+                .build();
+    }
+
+
+
+}

--- a/components/sbm-recipes-boot-upgrade/pom.xml
+++ b/components/sbm-recipes-boot-upgrade/pom.xml
@@ -95,14 +95,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <repositories>
-        <repository>
-            <id>spring-release</id>
-            <name>Spring Releases</name>
-            <url>https://repo.spring.io/release</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 </project>

--- a/components/sbm-recipes-boot-upgrade/pom.xml
+++ b/components/sbm-recipes-boot-upgrade/pom.xml
@@ -31,7 +31,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <spring-asciidoctor-backends.version>0.0.3</spring-asciidoctor-backends.version>
+        <spring-asciidoctor-backends.version>0.0.5</spring-asciidoctor-backends.version>
     </properties>
 
     <dependencies>

--- a/components/sbm-support-boot/src/main/resources/recipes/initialize-spring-boot-migration.yaml
+++ b/components/sbm-support-boot/src/main/resources/recipes/initialize-spring-boot-migration.yaml
@@ -14,9 +14,10 @@
 
     - type: org.springframework.sbm.build.migration.actions.AddMavenDependencyManagementAction
       condition:
-        type: org.springframework.sbm.build.migration.conditions.NoDependencyExistMatchingRegex
-        dependencies:
-          - 'org\.springframework\.boot'
+        type: org.springframework.sbm.build.migration.conditions.NoMoreRecentManagedDependencyExists
+        groupId: org.springframework.boot
+        artifactId: spring-boot-dependencies
+        version: 2.7.3
       name: "add managed dependency to Maven"
       groupId: org.springframework.boot
       artifactId: spring-boot-dependencies
@@ -33,7 +34,7 @@
                   <dependency>
                       <groupId>org.springframework.boot</groupId>
                       <artifactId>spring-boot-dependencies</artifactId>
-                      <version>2.6.3</version>
+                      <version>2.7.3</version>
                       <type>pom</type>
                       <scope>import</scope>
                   </dependency>
@@ -48,10 +49,10 @@
       dependencies:
         - groupId: org.springframework.boot
           artifactId: spring-boot-starter
-          version: 2.6.3 # OR finds the managed version and ignores this field
+          version: 2.7.3 # OR finds the managed version and ignores this field
         - groupId: org.springframework.boot
           artifactId: spring-boot-starter-test
-          version: 2.6.3
+          version: 2.7.3
           scope: test
       multiModuleHandler:
         type: org.springframework.sbm.build.migration.actions.AddDependenciesToApplicationModules


### PR DESCRIPTION
A better and more generic approach must be found.
A Spring baseline version should be defined and updated.
This would be the target version for JEE migration for example. 
So after migrating from a JEE application, it should be on the expected Spring version to allow upgrading from there.