### PR TITLE
Fix applicable recipe list holder

### DIFF
--- a/applications/spring-shell/src/main/java/org/springframework/sbm/shell/ApplyShellCommand.java
+++ b/applications/spring-shell/src/main/java/org/springframework/sbm/shell/ApplyShellCommand.java
@@ -26,6 +26,7 @@ import org.springframework.sbm.engine.commands.ApplyCommand;
 import org.springframework.sbm.engine.context.ProjectContext;
 import org.springframework.sbm.engine.context.ProjectContextHolder;
 import org.springframework.sbm.engine.recipe.Action;
+import org.springframework.sbm.engine.recipe.ApplicableRecipesListHolder;
 import org.springframework.sbm.engine.recipe.Recipe;
 import org.springframework.shell.Availability;
 import org.springframework.shell.CompletionContext;

--- a/applications/spring-shell/src/main/java/org/springframework/sbm/shell/ScanShellCommand.java
+++ b/applications/spring-shell/src/main/java/org/springframework/sbm/shell/ScanShellCommand.java
@@ -42,7 +42,6 @@ public class ScanShellCommand {
     private final PreconditionVerificationRenderer preconditionVerificationRenderer;
     private final ScanCommandHeaderRenderer scanCommandHeaderRenderer;
     private final ConsolePrinter consolePrinter;
-    private final ApplicableRecipesListHolder applicableRecipesListHolder;
 
     @ShellMethod(key = {"scan", "s"},
             value = "Scans the target project directory and get the list of applicable recipes.")
@@ -50,8 +49,6 @@ public class ScanShellCommand {
             @ShellOption(arity = 1, defaultValue = ".", valueProvider = ScanValueProvider.class,
                     help = "The root directory of the target application.")
                     String projectRoot) {
-
-        applicableRecipesListHolder.clear();
 
         List<Resource> resources = scanCommand.scanProjectRoot(projectRoot);
         String scanCommandHeader = scanCommandHeaderRenderer.renderHeader(projectRoot);
@@ -70,7 +67,6 @@ public class ScanShellCommand {
             ProjectContext projectContext = scanCommand.execute(projectRoot);
             contextHolder.setProjectContext(projectContext);
             List<Recipe> recipes = applicableRecipeListCommand.execute(projectContext);
-            applicableRecipesListHolder.setRecipes(recipes);
             AttributedString recipeList = applicableRecipeListRenderer.render(recipes);
             stringBuilder.append(recipeList);
         }

--- a/applications/spring-shell/src/test/java/org/springframework/sbm/shell/ScanShellCommandTest.java
+++ b/applications/spring-shell/src/test/java/org/springframework/sbm/shell/ScanShellCommandTest.java
@@ -31,6 +31,7 @@ import org.springframework.sbm.engine.commands.ScanCommand;
 import org.springframework.sbm.engine.context.ProjectContext;
 import org.springframework.sbm.engine.context.ProjectContextHolder;
 import org.springframework.sbm.engine.precondition.PreconditionVerificationResult;
+import org.springframework.sbm.engine.recipe.ApplicableRecipesListHolder;
 import org.springframework.sbm.engine.recipe.Recipe;
 
 import java.util.List;

--- a/applications/spring-shell/src/test/java/org/springframework/sbm/shell/ScanShellCommandWithWindowsPathTest.java
+++ b/applications/spring-shell/src/test/java/org/springframework/sbm/shell/ScanShellCommandWithWindowsPathTest.java
@@ -59,7 +59,7 @@ public class ScanShellCommandWithWindowsPathTest {
         recipes = List.of();
         projectContext = mock(ProjectContext.class);
 
-        sut = new ScanShellCommand(scanCommand, applicationRecipeListRenderer, applicableRecipeListCommand, contextHolder, preconditionVerificationRenderer, scanCommandHeaderRenderer, consolePrinter, new ApplicableRecipesListHolder());
+        sut = new ScanShellCommand(scanCommand, applicationRecipeListRenderer, applicableRecipeListCommand, contextHolder, preconditionVerificationRenderer, scanCommandHeaderRenderer, consolePrinter);
     }
 
     private void recordMocks(String projectRoot, ScanCommand scanCommand, ApplicableRecipeListRenderer applicationRecipeListRenderer, ApplicableRecipeListCommand applicableRecipeListCommand, List<Resource> resources, List<Recipe> recipes, ProjectContext projectContext) {

--- a/components/sbm-core/src/main/java/org/springframework/sbm/engine/commands/ApplicableRecipeListCommand.java
+++ b/components/sbm-core/src/main/java/org/springframework/sbm/engine/commands/ApplicableRecipeListCommand.java
@@ -23,6 +23,7 @@ import org.springframework.sbm.engine.recipe.Recipes;
 import org.springframework.sbm.engine.recipe.RecipesBuilder;
 import org.springframework.sbm.project.parser.ProjectContextInitializer;
 import org.springframework.sbm.scopes.ExecutionScope;
+import org.springframework.sbm.engine.recipe.ApplicableRecipesListHolder;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -38,14 +39,16 @@ public class ApplicableRecipeListCommand extends AbstractCommand<List<Recipe>> {
     private final ConfigurableListableBeanFactory beanFactory;
 
     private final ExecutionScope executionScope;
+    private final ApplicableRecipesListHolder applicableRecipesListHolder;
 
-    protected ApplicableRecipeListCommand(ProjectRootPathResolver projectRootPathResolver, RecipesBuilder recipesBuilder, ProjectContextInitializer projectContextBuilder, ConfigurableListableBeanFactory beanFactory, ExecutionScope executionScope) {
+    protected ApplicableRecipeListCommand(ProjectRootPathResolver projectRootPathResolver, RecipesBuilder recipesBuilder, ProjectContextInitializer projectContextBuilder, ConfigurableListableBeanFactory beanFactory, ExecutionScope executionScope, ApplicableRecipesListHolder applicableRecipesListHolder) {
         super(COMMAND_NAME);
         this.projectRootPathResolver = projectRootPathResolver;
         this.recipesBuilder = recipesBuilder;
         this.projectContextBuilder = projectContextBuilder;
         this.beanFactory = beanFactory;
         this.executionScope = executionScope;
+        this.applicableRecipesListHolder = applicableRecipesListHolder;
     }
 
     public List<Recipe> execute(ProjectContext projectContext) {
@@ -53,8 +56,11 @@ public class ApplicableRecipeListCommand extends AbstractCommand<List<Recipe>> {
     }
 
     private List<Recipe> getApplicableRecipes(ProjectContext context) {
+        applicableRecipesListHolder.clear();
         Recipes recipes = recipesBuilder.buildRecipes();
-        return recipes.getApplicable(context);
+        List<Recipe> applicable = recipes.getApplicable(context);
+        applicableRecipesListHolder.setRecipes(applicable);
+        return applicable;
     }
 
     @Override

--- a/components/sbm-core/src/main/java/org/springframework/sbm/engine/recipe/ApplicableRecipesListHolder.java
+++ b/components/sbm-core/src/main/java/org/springframework/sbm/engine/recipe/ApplicableRecipesListHolder.java
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.sbm.shell;
+package org.springframework.sbm.engine.recipe;
 
-import org.springframework.sbm.engine.recipe.Recipe;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;

--- a/components/sbm-core/src/main/java/org/springframework/sbm/java/impl/RewriteJavaParser.java
+++ b/components/sbm-core/src/main/java/org/springframework/sbm/java/impl/RewriteJavaParser.java
@@ -24,8 +24,6 @@ import org.openrewrite.java.marker.JavaSourceSet;
 import org.openrewrite.java.tree.J;
 import org.springframework.sbm.project.resource.SbmApplicationProperties;
 import org.springframework.sbm.scopes.annotations.ScanScope;
-import org.springframework.sbm.engine.annotations.StatefulComponent;
-import org.springframework.sbm.project.resource.SbmApplicationProperties;
 import org.springframework.stereotype.Component;
 
 import java.nio.file.Path;


### PR DESCRIPTION
Moves the handling of ApplicableRecipeListHolder from `ScanShellCommand` to `ApplyShellCommand`.