### PR TITLE
Remove missing recipe

### DIFF
--- a/components/sbm-recipes-boot-upgrade/src/main/resources/recipes/27_30/report/sbu30-report.yaml
+++ b/components/sbm-recipes-boot-upgrade/src/main/resources/recipes/27_30/report/sbu30-report.yaml
@@ -453,7 +453,6 @@
                 }
                 ----
 
-              recipe: sbu30-248-add-PathMatchConfigurer
           gitHubIssue: 522
           projects:
           - spring-boot


### PR DESCRIPTION
The `remove-sbu30-248-add-PathMatchConfigurer` recipe referenced in "Spring MVC and WebFlux URL matching changes" does not exist and the reference was removed.