### PR TITLE
Allow parsing a non-leaf module in a reactor build

### DIFF
--- a/sbm-support-rewrite/src/main/java/org/springframework/sbm/parsers/ClasspathExtractor.java
+++ b/sbm-support-rewrite/src/main/java/org/springframework/sbm/parsers/ClasspathExtractor.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 - 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sbm.parsers;
+
+import lombok.RequiredArgsConstructor;
+import org.openrewrite.maven.tree.MavenResolutionResult;
+import org.openrewrite.maven.tree.ResolvedDependency;
+import org.openrewrite.maven.tree.Scope;
+import org.openrewrite.maven.utilities.MavenArtifactDownloader;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+
+/**
+ * @author Fabian Krüger
+ */
+@RequiredArgsConstructor
+public class ClasspathExtractor {
+    private final MavenArtifactDownloader rewriteMavenArtifactDownloader;
+
+    public List<Path> extractClasspath(MavenResolutionResult pom, Scope scope) {
+        List<ResolvedDependency> resolvedDependencies = pom.getDependencies().get(scope);
+        if (resolvedDependencies != null) {
+            return resolvedDependencies
+                    // FIXME: 945 - deal with dependencies to projects in reactor
+                    //
+                    .stream()
+                    .filter(rd -> rd.getRepository() != null)
+                    .map(rd -> rewriteMavenArtifactDownloader.downloadArtifact(rd))
+                    .filter(Objects::nonNull)
+                    .distinct()
+                    .toList();
+        } else {
+            return new ArrayList<>();
+        }
+    }
+}

--- a/sbm-support-rewrite/src/main/java/org/springframework/sbm/parsers/JavaParserMarker.java
+++ b/sbm-support-rewrite/src/main/java/org/springframework/sbm/parsers/JavaParserMarker.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 - 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sbm.parsers;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.marker.Marker;
+
+import java.util.UUID;
+
+
+/**
+ * Used to keep the stateful {@link JavaParser} for later parsing.
+ *
+ * This is required when (re-)parsing a submodule somewhere (non-leaf) in a reactor build tree.
+ * Then this module requires the JavaParser with types from the last parse where types from lower modules are cached.
+ *
+ * @author Fabian Krüger
+ */
+@Value
+@With
+public class JavaParserMarker implements Marker {
+    private final UUID id;
+    private final JavaParser javaParser;
+}

--- a/sbm-support-rewrite/src/main/java/org/springframework/sbm/parsers/ModuleParser.java
+++ b/sbm-support-rewrite/src/main/java/org/springframework/sbm/parsers/ModuleParser.java
@@ -115,13 +115,14 @@ public class ModuleParser {
                 .map(r -> new Parser.Input(ResourceUtil.getPath(r), () -> ResourceUtil.getInputStream(r)))
                 .toList();
 
-        Stream<? extends SourceFile> cus = Stream.of(javaParserBuilder)
-                .map(JavaParser.Builder::build)
-                .flatMap(parser -> parser.parseInputs(inputs, baseDir, executionContext))
+        JavaParser javaParser = javaParserBuilder.build();
+        Stream<? extends SourceFile> cus = javaParser.parseInputs(inputs, baseDir, executionContext)
                 .peek(s -> alreadyParsed.add(baseDir.resolve(s.getSourcePath())));
+
 
         List<Marker> mainProjectProvenance = new ArrayList<>(provenanceMarkers);
         mainProjectProvenance.add(sourceSet("main", dependencies, typeCache));
+        mainProjectProvenance.add(new JavaParserMarker(UUID.randomUUID(), javaParser));
 
         // FIXME: 945 Why target and not all main?
         List<Path> parsedJavaPaths = mainJavaSources.stream().map(ResourceUtil::getPath).toList();

--- a/sbm-support-rewrite/src/main/java/org/springframework/sbm/parsers/ModuleParser.java
+++ b/sbm-support-rewrite/src/main/java/org/springframework/sbm/parsers/ModuleParser.java
@@ -104,7 +104,7 @@ public class ModuleParser {
         // Or, the classpath must be created from the sources of the project.
 
 
-        List<Path> dependencies = currentProject.getCompileClasspathElements();
+        Set<Path> dependencies = currentProject.getCompileClasspathElements();
 
         javaParserBuilder.classpath(dependencies);
 
@@ -148,7 +148,7 @@ public class ModuleParser {
     }
 
     @NotNull
-    private static JavaSourceSet sourceSet(String name, List<Path> dependencies, JavaTypeCache typeCache) {
+    private static JavaSourceSet sourceSet(String name, Set<Path> dependencies, JavaTypeCache typeCache) {
         return JavaSourceSet.build(name, dependencies, typeCache, false);
     }
 
@@ -168,7 +168,7 @@ public class ModuleParser {
     ) {
         log.info("Processing test sources in module '%s'".formatted(currentProject.getProjectId()));
 
-        List<Path> testDependencies = currentProject.getTestClasspathElements();
+        Set<Path> testDependencies = currentProject.getTestClasspathElements();
 
         javaParserBuilder.classpath(testDependencies);
         JavaTypeCache typeCache = new JavaTypeCache();

--- a/sbm-support-rewrite/src/main/java/org/springframework/sbm/parsers/ModuleParser.java
+++ b/sbm-support-rewrite/src/main/java/org/springframework/sbm/parsers/ModuleParser.java
@@ -73,7 +73,6 @@ public class ModuleParser {
     public List<SourceFile> processMainSources(
             Path baseDir,
             List<Resource> resources,
-            Xml.Document moduleBuildFile,
             JavaParser.Builder<? extends JavaParser, ?> javaParserBuilder,
             RewriteResourceParser rp,
             List<Marker> provenanceMarkers,
@@ -159,7 +158,6 @@ public class ModuleParser {
      */
     public List<SourceFile> processTestSources(
             Path baseDir,
-            Xml.Document moduleBuildFile,
             JavaParser.Builder<? extends JavaParser, ?> javaParserBuilder,
             RewriteResourceParser rp,
             List<Marker> provenanceMarkers,

--- a/sbm-support-rewrite/src/main/java/org/springframework/sbm/parsers/ModuleParsingResult.java
+++ b/sbm-support-rewrite/src/main/java/org/springframework/sbm/parsers/ModuleParsingResult.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 - 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sbm.parsers;
+
+import org.openrewrite.SourceFile;
+
+import java.util.List;
+
+/**
+ * @author Fabian Krüger
+ */
+public record ModuleParsingResult(List<SourceFile> sourceFiles) {
+
+}

--- a/sbm-support-rewrite/src/main/java/org/springframework/sbm/parsers/RewriteParserConfiguration.java
+++ b/sbm-support-rewrite/src/main/java/org/springframework/sbm/parsers/RewriteParserConfiguration.java
@@ -103,6 +103,11 @@ public class RewriteParserConfiguration {
     }
 
     @Bean
+    ClasspathExtractor classpathExtractor(MavenArtifactDownloader rewriteMavenArtifactDownloader) {
+        return new ClasspathExtractor(rewriteMavenArtifactDownloader);
+    }
+
+    @Bean
     RewriteMavenArtifactDownloader artifactDownloader(MavenArtifactCache mavenArtifactCache, ProjectMetadata projectMetadata, Consumer<Throwable> artifactDownloaderErrorConsumer) {
         return new RewriteMavenArtifactDownloader(mavenArtifactCache, projectMetadata.getMavenSettings(), artifactDownloaderErrorConsumer);
     }
@@ -147,8 +152,8 @@ public class RewriteParserConfiguration {
 //    }
 
     @Bean
-    MavenProjectAnalyzer mavenProjectAnalyzer(MavenArtifactDownloader artifactDownloader) {
-        return new MavenProjectAnalyzer(artifactDownloader);
+    MavenProjectAnalyzer mavenProjectAnalyzer(MavenArtifactDownloader artifactDownloader, ClasspathExtractor classpathExtractor) {
+        return new MavenProjectAnalyzer(artifactDownloader, classpathExtractor);
     }
 
     @Bean

--- a/sbm-support-rewrite/src/main/java/org/springframework/sbm/parsers/RewriteParserConfiguration.java
+++ b/sbm-support-rewrite/src/main/java/org/springframework/sbm/parsers/RewriteParserConfiguration.java
@@ -152,8 +152,8 @@ public class RewriteParserConfiguration {
 //    }
 
     @Bean
-    MavenProjectAnalyzer mavenProjectAnalyzer(MavenArtifactDownloader artifactDownloader, ClasspathExtractor classpathExtractor) {
-        return new MavenProjectAnalyzer(artifactDownloader, classpathExtractor);
+    MavenProjectAnalyzer mavenProjectAnalyzer(ClasspathExtractor classpathExtractor) {
+        return new MavenProjectAnalyzer(classpathExtractor);
     }
 
     @Bean

--- a/sbm-support-rewrite/src/main/java/org/springframework/sbm/parsers/maven/MavenModuleParser.java
+++ b/sbm-support-rewrite/src/main/java/org/springframework/sbm/parsers/maven/MavenModuleParser.java
@@ -90,8 +90,8 @@ public class MavenModuleParser {
         Path moduleBuildFilePath = baseDir.resolve(moduleBuildFile.getSourcePath());
         alreadyParsed.add(moduleBuildFilePath);
         alreadyParsed.addAll(skipResourceScanDirs);
-        List<SourceFile> mainSources = parseMainSources(baseDir, currentProject, moduleBuildFile, resources, javaParserBuilder.clone(), rp, provenanceMarkers, alreadyParsed, executionContext);
-        List<SourceFile> testSources = parseTestSources(baseDir, currentProject, moduleBuildFile, javaParserBuilder.clone(), rp, provenanceMarkers, alreadyParsed, executionContext, resources);
+        List<SourceFile> mainSources = parseMainSources(baseDir, currentProject, resources, javaParserBuilder.clone(), rp, provenanceMarkers, alreadyParsed, executionContext);
+        List<SourceFile> testSources = parseTestSources(baseDir, currentProject, javaParserBuilder.clone(), rp, provenanceMarkers, alreadyParsed, executionContext, resources);
         // Collect the dirs of modules parsed in previous steps
 
         // parse other project resources
@@ -124,20 +124,20 @@ public class MavenModuleParser {
                 .noneMatch(pm -> pm.matches(baseDir.resolve(s.getSourcePath()).toAbsolutePath().normalize()));
     }
 
-    private List<SourceFile> parseTestSources(Path baseDir, MavenProject mavenProject, Xml.Document moduleBuildFile, JavaParser.Builder<? extends JavaParser, ?> javaParserBuilder, RewriteResourceParser rp, List<Marker> provenanceMarkers, Set<Path> alreadyParsed, ExecutionContext executionContext, List<Resource> resources) {
-        return mavenMojoProjectParserPrivateMethods.processTestSources(baseDir, moduleBuildFile, javaParserBuilder, rp, provenanceMarkers, alreadyParsed, executionContext, mavenProject, resources);
+    private List<SourceFile> parseTestSources(Path baseDir, MavenProject mavenProject, JavaParser.Builder<? extends JavaParser, ?> javaParserBuilder, RewriteResourceParser rp, List<Marker> provenanceMarkers, Set<Path> alreadyParsed, ExecutionContext executionContext, List<Resource> resources) {
+        return mavenMojoProjectParserPrivateMethods.processTestSources(baseDir, javaParserBuilder, rp, provenanceMarkers, alreadyParsed, executionContext, mavenProject, resources);
     }
 
     /**
      */
-    private List<SourceFile> parseMainSources(Path baseDir, MavenProject mavenProject, Xml.Document moduleBuildFile, List<Resource> resources, JavaParser.Builder<? extends JavaParser, ?> javaParserBuilder, RewriteResourceParser rp, List<Marker> provenanceMarkers, Set<Path> alreadyParsed, ExecutionContext executionContext) {
+    private List<SourceFile> parseMainSources(Path baseDir, MavenProject mavenProject, List<Resource> resources, JavaParser.Builder<? extends JavaParser, ?> javaParserBuilder, RewriteResourceParser rp, List<Marker> provenanceMarkers, Set<Path> alreadyParsed, ExecutionContext executionContext) {
         // MavenMojoProjectParser#processMainSources(..) takes MavenProject
         // it reads from it:
         // - mavenProject.getBuild().getDirectory()
         // - mavenProject.getBuild().getSourceDirectory()
         // - mavenProject.getCompileClasspathElements() --> The classpath of the given project/module
         // - mavenProject.getBasedir().toPath()
-        return mavenMojoProjectParserPrivateMethods.processMainSources(baseDir, resources, moduleBuildFile, javaParserBuilder, rp, provenanceMarkers, alreadyParsed, executionContext, mavenProject);
+        return mavenMojoProjectParserPrivateMethods.processMainSources(baseDir, resources, javaParserBuilder, rp, provenanceMarkers, alreadyParsed, executionContext, mavenProject);
 //        return invokeProcessMethod(baseDir, moduleBuildFile, javaParserBuilder, rp, provenanceMarkers, alreadyParsed, executionContext, "processMainSources");
     }
 

--- a/sbm-support-rewrite/src/main/java/org/springframework/sbm/parsers/maven/MavenModuleParser.java
+++ b/sbm-support-rewrite/src/main/java/org/springframework/sbm/parsers/maven/MavenModuleParser.java
@@ -169,22 +169,6 @@ public class MavenModuleParser {
     }
 
     private List<SourceFile> parseMainSources(Path baseDir, Collection<Path> classpath, Collection<byte[]> classBytesClasspath, List<Resource> resources) {
-        List<byte[]> array = classBytesClasspath
-                .stream()
-                .map(b -> {
-                    return (byte[]) b;
-                })
-                .toList();
-
-        List<byte[]> classBytesClasspathList = new ArrayList<>();
-        classBytesClasspathList.addAll(classBytesClasspath);
-
-        byte[][] classBytesClasspathArray = new byte[classBytesClasspath.size()][];
-        for(int i=0; i<classBytesClasspathList.size(); i++) {
-            byte[] bytes = classBytesClasspathList.get(i);
-            classBytesClasspathArray[i] = bytes;
-        }
-        JavaParser.fromJavaVersion().classpath(classBytesClasspathArray);
         return new ArrayList<>();
     }
 

--- a/sbm-support-rewrite/src/main/java/org/springframework/sbm/parsers/maven/MavenProjectAnalyzer.java
+++ b/sbm-support-rewrite/src/main/java/org/springframework/sbm/parsers/maven/MavenProjectAnalyzer.java
@@ -20,6 +20,7 @@ import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.openrewrite.maven.utilities.MavenArtifactDownloader;
 import org.springframework.core.io.Resource;
+import org.springframework.sbm.parsers.ClasspathExtractor;
 import org.springframework.sbm.parsers.MavenProject;
 import org.springframework.sbm.parsers.ParserContext;
 import org.springframework.sbm.utils.ResourceUtil;
@@ -42,9 +43,11 @@ public class MavenProjectAnalyzer {
     private static final String POM_XML = "pom.xml";
     private static final MavenXpp3Reader XPP_3_READER = new MavenXpp3Reader();
     private final MavenArtifactDownloader rewriteMavenArtifactDownloader;
+    private final ClasspathExtractor classpathExtractor;
 
-    public MavenProjectAnalyzer(MavenArtifactDownloader rewriteMavenArtifactDownloader) {
+    public MavenProjectAnalyzer(MavenArtifactDownloader rewriteMavenArtifactDownloader, ClasspathExtractor classpathExtractor) {
         this.rewriteMavenArtifactDownloader = rewriteMavenArtifactDownloader;
+        this.classpathExtractor = classpathExtractor;
     }
 
     public List<MavenProject> getSortedProjects(Path baseDir, List<Resource> resources) {
@@ -59,7 +62,7 @@ public class MavenProjectAnalyzer {
         Model rootPomModel = new Model(rootPom);
 
         if (isSingleModuleProject(rootPomModel)) {
-            return List.of(new MavenProject(baseDir, rootPom, rootPomModel, rewriteMavenArtifactDownloader, resources));
+            return List.of(new MavenProject(baseDir, rootPom, rootPomModel, resources));
         }
         List<Model> reactorModels = new ArrayList<>();
         recursivelyFindReactorModules(baseDir, null, reactorModels, allPomFiles, rootPomModel);
@@ -75,7 +78,7 @@ public class MavenProjectAnalyzer {
                 .forEach(m -> {
                     String projectDir = baseDir.resolve(m.getProjectDirectory().toString()).normalize().toString();
                     List<Resource> filteredResources = resources.stream().filter(r -> ResourceUtil.getPath(r).toString().startsWith(projectDir)).toList();
-                    mavenProjects.add(new MavenProject(baseDir, m.getResource(), m, rewriteMavenArtifactDownloader, filteredResources));
+                    mavenProjects.add(new MavenProject(baseDir, m.getResource(), m, filteredResources));
         });
         // set all non parent poms as collected projects for root parent pom
         List<MavenProject> collected = new ArrayList<>(mavenProjects);

--- a/sbm-support-rewrite/src/main/java/org/springframework/sbm/parsers/maven/MavenProjectAnalyzer.java
+++ b/sbm-support-rewrite/src/main/java/org/springframework/sbm/parsers/maven/MavenProjectAnalyzer.java
@@ -42,11 +42,9 @@ public class MavenProjectAnalyzer {
 
     private static final String POM_XML = "pom.xml";
     private static final MavenXpp3Reader XPP_3_READER = new MavenXpp3Reader();
-    private final MavenArtifactDownloader rewriteMavenArtifactDownloader;
     private final ClasspathExtractor classpathExtractor;
 
-    public MavenProjectAnalyzer(MavenArtifactDownloader rewriteMavenArtifactDownloader, ClasspathExtractor classpathExtractor) {
-        this.rewriteMavenArtifactDownloader = rewriteMavenArtifactDownloader;
+    public MavenProjectAnalyzer(ClasspathExtractor classpathExtractor) {
         this.classpathExtractor = classpathExtractor;
     }
 

--- a/sbm-support-rewrite/src/test/java/org/springframework/sbm/parsers/MavenModuleParserTest.java
+++ b/sbm-support-rewrite/src/test/java/org/springframework/sbm/parsers/MavenModuleParserTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.SourceFile;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.internal.JavaTypeCache;
@@ -31,6 +32,8 @@ import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.maven.cache.InMemoryMavenPomCache;
 import org.openrewrite.maven.cache.LocalMavenArtifactCache;
+import org.openrewrite.maven.tree.MavenResolutionResult;
+import org.openrewrite.maven.tree.Scope;
 import org.openrewrite.maven.utilities.MavenArtifactDownloader;
 import org.openrewrite.style.NamedStyles;
 import org.openrewrite.xml.tree.Xml;
@@ -175,4 +178,242 @@ public class MavenModuleParserTest {
             assertThat(compilationUnitB.getMarkers().getMarkers()).isEmpty();
         }
     }
+
+
+    @Test
+    @DisplayName("parse simple project")
+    void parseSimpleProject() {
+        @Language("xml")
+        String pomXml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                        <groupId>com.example</groupId>
+                        <artifactId>example-1-parent</artifactId>
+                        <version>0.1.0-SNAPSHOT</version>
+                    </parent>
+                    <artifactId>app</artifactId>
+                    <properties>
+                        <maven.compiler.target>17</maven.compiler.target>
+                        <maven.compiler.source>17</maven.compiler.source>
+                    </properties>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.junit.jupiter</groupId>
+                            <artifactId>junit-jupiter-api</artifactId>
+                            <version>5.9.3</version><scope>test</scope>
+                            <scope>test</scope>
+                        </dependency>
+                        <dependency>
+                            <groupId>javax.validation</groupId>
+                            <artifactId>validation-api</artifactId>
+                            <version>2.0.1.Final</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """;
+        @Language("java")
+        String mainClass = """
+                package com.example.app;
+                import javax.validation.constraints.Min;
+                                
+                public class MainClass {
+                    @Min("0")
+                    private int number;
+                }
+                """;
+        @Language("java")
+        String testClass = """
+                package com.example.app.test;
+                import org.junit.jupiter.api.Test;
+                import com.example.app.MainClass;
+                                
+                public class SomeTest {
+                    @Test
+                    void someTest() {
+                        MainClass m = new MainClass();
+                    }
+                }
+                """;
+
+        Path baseDir = Path.of("./target").toAbsolutePath().normalize();
+
+        Path pomXmlPath = baseDir.resolve("pom.xml").normalize();
+        List<Resource> resources = List.of(
+                new DummyResource(pomXmlPath, pomXml),
+                new DummyResource(baseDir.resolve("src/main/java/com/example/app/MainClass.java"), mainClass),
+                new DummyResource(baseDir.resolve("src/test/java/com/example/app/test/SomeTest.java"), testClass)
+        );
+
+        MavenRuntimeInformation mavenRuntimeInfo = new MavenRuntimeInformation();
+        Plugin compilerPlugin = null;
+        Properties properties = new Properties();
+        String projectName = "app";
+        String groupId = "com.example";
+        String artifactId = "app";
+        String version = "1.0.0-SNAPSHOT";
+
+        List<Marker> provenanceMarkers = new MavenProvenanceMarkerFactory().generateProvenanceMarkers(
+                baseDir,
+                mavenRuntimeInfo,
+                compilerPlugin,
+                properties,
+                projectName,
+                groupId,
+                artifactId,
+                version
+        );
+        Map<Path, List<Marker>> provenanceMarkersMap = Map.of(pomXmlPath, provenanceMarkers);
+        BuildFileParser buildFileParser = new BuildFileParser();
+        List<Xml.Document> parsedBuildFiles = buildFileParser.parseBuildFiles(baseDir, List.of(resources.get(0)), List.of(), new RewriteExecutionContext(), false, provenanceMarkersMap);
+        Xml.Document document = parsedBuildFiles.get(0);
+
+
+        Collection<Path> classpath = new ArrayList<>();
+        Collection<byte[]> classBytesClasspath = new ArrayList<>();
+
+        ModuleParsingResult moduleParsingResult = sut.parseModule(baseDir, "", classpath, classBytesClasspath, resources);
+
+        assertThat(moduleParsingResult.sourceFiles()).hasSize(2);
+        assertThat(moduleParsingResult.sourceFiles().get(0).printAll()).isEqualTo(mainClass);
+    }
+
+    @Test
+    @DisplayName("parse reactor project")
+    void parseReactorProject() {
+        @Language("xml")
+        String parentPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>com.example</groupId>
+                    <artifactId>example-1-parent</artifactId>
+                    <version>0.1.0-SNAPSHOT</version>
+                    <packaging>pom</packaging>
+                    <properties>
+                         <maven.compiler.target>17</maven.compiler.target>
+                         <maven.compiler.source>17</maven.compiler.source>
+                    </properties>
+                    <modules>
+                        <module>module-a</module>
+                        <module>module-b</module>
+                        <module>module-c</module>
+                    </modules>
+                </project>
+                """;
+
+        @Language("xml")
+        String moduleAPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                        <groupId>com.example</groupId>
+                        <artifactId>example-1-parent</artifactId>
+                        <version>0.1.0-SNAPSHOT</version>
+                    </parent>
+                    <artifactId>module-a</artifactId>
+                    <properties>
+                        <maven.compiler.target>17</maven.compiler.target>
+                        <maven.compiler.source>17</maven.compiler.source>
+                    </properties>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.example</groupId>
+                            <artifactId>module-b</artifactId>
+                            <version>${project.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>javax.validation</groupId>
+                            <artifactId>validation-api</artifactId>
+                            <version>2.0.1.Final</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """;
+
+        @Language("xml")
+        String moduleBPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                        <groupId>com.example</groupId>
+                        <artifactId>example-1-parent</artifactId>
+                        <version>0.1.0-SNAPSHOT</version>
+                    </parent>
+                    <artifactId>module-b</artifactId>
+                    <properties>
+                        <maven.compiler.target>17</maven.compiler.target>
+                        <maven.compiler.source>17</maven.compiler.source>
+                    </properties>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.example</groupId>
+                            <artifactId>module-c</artifactId>
+                            <version>${project.version}</version>
+                        </dependency>
+                    </dependencies>                  
+                </project>
+                """;
+
+        @Language("xml")
+        String moduleCPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                        <groupId>com.example</groupId>
+                        <artifactId>example-1-parent</artifactId>
+                        <version>0.1.0-SNAPSHOT</version>
+                    </parent>
+                    <artifactId>module-c</artifactId>
+                    <properties>
+                        <maven.compiler.target>17</maven.compiler.target>
+                        <maven.compiler.source>17</maven.compiler.source>
+                    </properties>
+                </project>
+                """;
+
+        Path baseDir = Path.of("./target").toAbsolutePath().normalize();
+        List<Resource> resources = List.of(
+                new DummyResource(baseDir.resolve("pom.xml"), parentPom),
+                new DummyResource(baseDir.resolve("module-a/pom.xml"), moduleAPom),
+                new DummyResource(baseDir.resolve("module-b/pom.xml"), moduleBPom),
+                new DummyResource(baseDir.resolve("module-c/pom.xml"), moduleCPom)
+        );
+        ExecutionContext executionContext = new InMemoryExecutionContext();
+/*
+        // used to calculate paths to other modules.
+        // TODO: Remove and filter all provided resources by module path segment
+        MavenProject mavenProject = null;
+        // used to retrieve sourcePath which can be calculated having the module path segment and baseDir
+        Xml.Document moduleBuildFile = null;
+        // required, can be taken from a resource in same source dir?!
+        List<Marker> provenanceMarkers = null;
+        // Make this a Spring bean
+        List<NamedStyles> styles = null;
+        // provided as bean
+        ExecutionContext executionContext = null;
+        // required
+        Path baseDir = null;
+        sut.parseModuleSourceFiles(resources, mavenProject, moduleBuildFile, provenanceMarkers, styles, executionContext, baseDir);
+*/
+        BuildFileParser buildFileParser = new BuildFileParser();
+        List<Xml.Document> parsedBuildFiles = buildFileParser.parseBuildFiles(baseDir, resources, List.of(), executionContext, false, Map.of());
+
+        Path locaMavenRepo = Path.of(System.getProperty("user.home")).resolve(".m2/repository");
+        MavenArtifactDownloader artifactDownloader = new RewriteMavenArtifactDownloader(new LocalMavenArtifactCache(locaMavenRepo), null, t -> {throw new RuntimeException(t);});
+        ClasspathExtractor classpathExtractor = new ClasspathExtractor(artifactDownloader);
+        List<Path> classpath = classpathExtractor.extractClasspath(parsedBuildFiles.get(0).getMarkers().findFirst(MavenResolutionResult.class).get(), Scope.Compile);
+        Collection<byte[]> classBytesClasspath = List.of();
+        String modulePathSegment = "module-c";
+        ModuleParsingResult result = sut.parseModule(baseDir, modulePathSegment, classpath, classBytesClasspath, resources);
+        assertThat(result.sourceFiles()).hasSize(0);
+    }
+
 }

--- a/sbm-support-rewrite/src/test/java/org/springframework/sbm/parsers/MavenModuleParserTest.java
+++ b/sbm-support-rewrite/src/test/java/org/springframework/sbm/parsers/MavenModuleParserTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2021 - 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sbm.parsers;
+
+import org.apache.maven.model.Plugin;
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.SourceFile;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.internal.JavaTypeCache;
+import org.openrewrite.java.marker.JavaSourceSet;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.marker.Marker;
+import org.openrewrite.maven.cache.InMemoryMavenPomCache;
+import org.openrewrite.maven.cache.LocalMavenArtifactCache;
+import org.openrewrite.maven.utilities.MavenArtifactDownloader;
+import org.openrewrite.style.NamedStyles;
+import org.openrewrite.xml.tree.Xml;
+import org.springframework.core.io.Resource;
+import org.springframework.sbm.parsers.maven.BuildFileParser;
+import org.springframework.sbm.parsers.maven.MavenModuleParser;
+import org.springframework.sbm.parsers.maven.MavenProvenanceMarkerFactory;
+import org.springframework.sbm.parsers.maven.MavenRuntimeInformation;
+import org.springframework.sbm.test.util.DummyResource;
+
+import java.nio.file.Path;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Fabian Krüger
+ */
+public class MavenModuleParserTest {
+
+    private MavenModuleParser sut;
+
+    @BeforeEach
+    void beforeEach() {
+        sut = new MavenModuleParser(new ParserProperties(), new ModuleParser());
+    }
+
+    /**
+     * Tests proving the behaviour of JavaParser in combination with JavaTypeCache
+     */
+    @Nested
+    class JavaCompilerTypeResolutionTest {
+
+        // Simple class A
+        String aSource = """
+                    package com.foo;
+                    public class A{}
+                    """;
+
+        // Simple class B extending A
+        String bSource = """
+                    package com.bar;
+                    import com.foo.A;
+                    public class B extends A {}
+                    """;
+        private JavaParser.Builder<? extends JavaParser, ?> builder;
+
+        @BeforeEach
+        void beforeEach() {
+            builder = JavaParser.fromJavaVersion();
+        }
+
+        // Parse A and B with one call to parse() on same instance
+        // Same parser, same call, same type cache
+        // -> Should resolve type A
+        @Test
+        @DisplayName("Same parser with shared type cache and one call should resolve types")
+        void sameParserWithSharedTypeCacheAndOneCallShouldResolveTypes() {
+            JavaParser javaParser = builder.build();
+
+            List<SourceFile> parse = javaParser.parse(aSource, bSource).toList();
+
+            String fullyQualifiedName = ((JavaType.FullyQualified) ((J.CompilationUnit) parse.get(1)).getClasses().get(0).getExtends().getType()).getFullyQualifiedName();
+            assertThat(fullyQualifiedName).isEqualTo("com.foo.A");
+        }
+
+        // Parse A and B with separate calls to parse() on separate instances with separate type cache
+        // Different parser, two calls, different type cache
+        // -> Should NOT resolve type A
+        @Test
+        @DisplayName("Different parsers with separate caches and separate calls should not resolve types")
+        void differentParsersWithSeparateCachesAndSeparateCallsShouldNotResolveTypes() {
+            // parser 1 with dedicated type cache
+            JavaTypeCache typeCache = new JavaTypeCache();
+            builder.typeCache(typeCache);
+            JavaParser javaParser = builder.build();
+            SourceFile a = javaParser.parse(aSource).toList().get(0);
+
+            // parser 2 with dedicated type cache
+            JavaTypeCache typeCache2 = new JavaTypeCache();
+            builder.typeCache(typeCache2);
+            JavaParser javaParser2 = builder.build();
+            SourceFile b = javaParser2.parse(bSource).toList().get(0);
+
+            // Type A used in B not resolved
+            String fullyQualifiedName2 = ((JavaType.FullyQualified) ((J.CompilationUnit) b).getClasses().get(0).getExtends().getType()).getFullyQualifiedName();
+            String unknown = JavaType.Unknown.getInstance().getFullyQualifiedName();
+            assertThat(fullyQualifiedName2).isEqualTo(unknown);
+        }
+
+        // Parse A and B with separate calls to parse() on separate instances with SHARED type cache
+        // Different parser, two calls, same type cache
+        // -> Should NOT resolve type A
+        // -> Sharing the type cache is not enough!
+        @Test
+        @DisplayName("Different parsers with shared cache and separate calls should NOT resolve types")
+        void differentParsersWithSharedCacheAndSeparateCallsShouldNotResolveTypes() {
+            // Shared type cache
+            JavaTypeCache typeCache = new JavaTypeCache();
+            builder.typeCache(typeCache);
+
+            // parser 1
+            JavaParser javaParser = builder.build();
+            // parser 2
+            JavaParser javaParser2 = builder.build();
+
+            SourceFile a = javaParser.parse(aSource).toList().get(0);
+            SourceFile b = javaParser2.parse(bSource).toList().get(0);
+
+            // Type A used in B IS resolved
+            String fullyQualifiedName = ((JavaType.FullyQualified) ((J.CompilationUnit) b).getClasses().get(0).getExtends().getType()).getFullyQualifiedName();
+            String unknown = JavaType.Unknown.getInstance().getFullyQualifiedName();
+            assertThat(fullyQualifiedName).isEqualTo(unknown);
+        }
+
+        // Parse A and B with separate calls to parse() on SAME instances with SHARED type cache
+        // Same parser, two calls, same type cache
+        // -> Should resolve type A
+        // -> Same parser, separate calls, same type cache
+        // --> WORKS! That's what we need.
+        @Test
+        @DisplayName("Same parser with shared cache in separate calls should resolve types")
+        void sameParserWithSharedCacheInSeparateCallsShouldResolveTypes() {
+            // One shared type cache
+            JavaTypeCache typeCache = new JavaTypeCache();
+            builder.typeCache(typeCache);
+            JavaParser javaParser = builder.build();
+
+            // Same parser two calls
+            SourceFile a = javaParser.parse(aSource).toList().get(0);
+            SourceFile b = javaParser.parse(bSource).toList().get(0);
+
+            J.CompilationUnit compilationUnitB = (J.CompilationUnit) b;
+            String fullyQualifiedName2 = ((JavaType.FullyQualified) compilationUnitB.getClasses().get(0).getExtends().getType()).getFullyQualifiedName();
+            // A can be resolved
+            assertThat(fullyQualifiedName2).isEqualTo("com.foo.A");
+
+            List<String> bTypesInUseFqNames = compilationUnitB.getTypesInUse().getTypesInUse().stream().map(fq -> ((JavaType.FullyQualified) fq).getFullyQualifiedName()).toList();
+            // A is in typesInUse of B
+            assertThat(bTypesInUseFqNames).contains("com.foo.A");
+            //No markers were set
+            assertThat(compilationUnitB.getMarkers().getMarkers()).isEmpty();
+        }
+    }
+}

--- a/sbm-support-rewrite/src/test/java/org/springframework/sbm/parsers/RewriteProjectParserTest.java
+++ b/sbm-support-rewrite/src/test/java/org/springframework/sbm/parsers/RewriteProjectParserTest.java
@@ -107,7 +107,7 @@ class RewriteProjectParserTest {
                 mock(ConfigurableListableBeanFactory.class),
                 new ProjectScanner(new DefaultResourceLoader(), parserProperties),
                 executionContext,
-                new MavenProjectAnalyzer(mock(RewriteMavenArtifactDownloader.class), classpathExtractor)
+                new MavenProjectAnalyzer(new ClasspathExtractor(mock(RewriteMavenArtifactDownloader.class)))
         );
 
         List<String> parsedFiles = new ArrayList<>();

--- a/sbm-support-rewrite/src/test/java/org/springframework/sbm/parsers/RewriteProjectParserTest.java
+++ b/sbm-support-rewrite/src/test/java/org/springframework/sbm/parsers/RewriteProjectParserTest.java
@@ -23,6 +23,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Parser;
 import org.openrewrite.SourceFile;
+import org.openrewrite.maven.cache.LocalMavenArtifactCache;
 import org.openrewrite.tree.ParsingEventListener;
 import org.openrewrite.tree.ParsingExecutionContextView;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
@@ -92,6 +93,8 @@ class RewriteProjectParserTest {
         ModuleParser mavenMojoParserPrivateMethods = new ModuleParser();
         ExecutionContext executionContext = new InMemoryExecutionContext(t -> {throw new RuntimeException(t);});
         MavenModuleParser mavenModuleParser = new MavenModuleParser(parserProperties, mavenMojoParserPrivateMethods);
+        Path localMavenRepo = Path.of(System.getProperty("user.home")).resolve(".m2/repository");
+        ClasspathExtractor classpathExtractor = new ClasspathExtractor(new RewriteMavenArtifactDownloader(new LocalMavenArtifactCache(localMavenRepo), null, t -> {throw new RuntimeException(t);}));
         RewriteProjectParser projectParser = new RewriteProjectParser(
                 new ProvenanceMarkerFactory(new MavenProvenanceMarkerFactory()),
                 new BuildFileParser(),
@@ -104,7 +107,7 @@ class RewriteProjectParserTest {
                 mock(ConfigurableListableBeanFactory.class),
                 new ProjectScanner(new DefaultResourceLoader(), parserProperties),
                 executionContext,
-                new MavenProjectAnalyzer(mock(RewriteMavenArtifactDownloader.class))
+                new MavenProjectAnalyzer(mock(RewriteMavenArtifactDownloader.class), classpathExtractor)
         );
 
         List<String> parsedFiles = new ArrayList<>();

--- a/sbm-support-rewrite/src/test/java/org/springframework/sbm/parsers/maven/MavenProjectAnalyzerTest.java
+++ b/sbm-support-rewrite/src/test/java/org/springframework/sbm/parsers/maven/MavenProjectAnalyzerTest.java
@@ -50,7 +50,7 @@ class MavenProjectAnalyzerTest {
     @BeforeEach
     void beforeEach() {
         MavenArtifactDownloader rewriteMavenArtifactDownloader = Mockito.mock(RewriteMavenArtifactDownloader.class);
-        sut = new MavenProjectAnalyzer(rewriteMavenArtifactDownloader);
+        sut = new MavenProjectAnalyzer(rewriteMavenArtifactDownloader, classpathExtractor);
     }
 
     @Nested

--- a/sbm-support-rewrite/src/test/java/org/springframework/sbm/parsers/maven/MavenProjectAnalyzerTest.java
+++ b/sbm-support-rewrite/src/test/java/org/springframework/sbm/parsers/maven/MavenProjectAnalyzerTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 import org.openrewrite.maven.utilities.MavenArtifactDownloader;
 import org.springframework.core.io.Resource;
+import org.springframework.sbm.parsers.ClasspathExtractor;
 import org.springframework.sbm.parsers.MavenProject;
 import org.springframework.sbm.parsers.RewriteMavenArtifactDownloader;
 import org.springframework.sbm.test.util.DummyResource;
@@ -50,7 +51,8 @@ class MavenProjectAnalyzerTest {
     @BeforeEach
     void beforeEach() {
         MavenArtifactDownloader rewriteMavenArtifactDownloader = Mockito.mock(RewriteMavenArtifactDownloader.class);
-        sut = new MavenProjectAnalyzer(rewriteMavenArtifactDownloader, classpathExtractor);
+        ClasspathExtractor classpathExtractor = new ClasspathExtractor(rewriteMavenArtifactDownloader);
+        sut = new MavenProjectAnalyzer(classpathExtractor);
     }
 
     @Nested

--- a/sbm-support-rewrite/src/test/java/org/springframework/sbm/parsers/maven/RewriteMavenProjectParserTest.java
+++ b/sbm-support-rewrite/src/test/java/org/springframework/sbm/parsers/maven/RewriteMavenProjectParserTest.java
@@ -281,7 +281,7 @@ class RewriteMavenProjectParserTest {
                 beanFactory,
                 new ProjectScanner(new DefaultResourceLoader(), parserProperties),
                 new RewriteExecutionContext(),
-                new MavenProjectAnalyzer(mock(RewriteMavenArtifactDownloader.class), classpathExtractor)
+                new MavenProjectAnalyzer(new ClasspathExtractor(mock(RewriteMavenArtifactDownloader.class)))
         );
 
         Set<String> ignoredPatters = Set.of();

--- a/sbm-support-rewrite/src/test/java/org/springframework/sbm/parsers/maven/RewriteMavenProjectParserTest.java
+++ b/sbm-support-rewrite/src/test/java/org/springframework/sbm/parsers/maven/RewriteMavenProjectParserTest.java
@@ -16,7 +16,6 @@
 package org.springframework.sbm.parsers.maven;
 
 import org.intellij.lang.annotations.Language;
-import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -40,8 +39,6 @@ import org.openrewrite.marker.ci.GithubActionsBuildEnvironment;
 import org.openrewrite.maven.MavenExecutionContextView;
 import org.openrewrite.maven.MavenSettings;
 import org.openrewrite.maven.cache.*;
-import org.openrewrite.maven.cache.LocalMavenArtifactCache;
-import org.openrewrite.maven.cache.MavenArtifactCache;
 import org.openrewrite.maven.tree.MavenResolutionResult;
 import org.openrewrite.shaded.jgit.api.Git;
 import org.openrewrite.shaded.jgit.api.errors.GitAPIException;
@@ -64,7 +61,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.io.File;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -285,7 +281,7 @@ class RewriteMavenProjectParserTest {
                 beanFactory,
                 new ProjectScanner(new DefaultResourceLoader(), parserProperties),
                 new RewriteExecutionContext(),
-                new MavenProjectAnalyzer(mock(RewriteMavenArtifactDownloader.class))
+                new MavenProjectAnalyzer(mock(RewriteMavenArtifactDownloader.class), classpathExtractor)
         );
 
         Set<String> ignoredPatters = Set.of();


### PR DESCRIPTION
Example:

Given a reactor build with four `pom.xml`: `parent`, `A`, `B`, and `C` where `A` depends on `B` and `B` depends on `C`.

![reactor-build](https://github.com/spring-projects-experimental/spring-boot-migrator/assets/56278322/6e23c0d5-be6a-4ec4-a699-40dfbc381fd6)

When a dependency is added to `B` and the classpath changed

Then modules `A` and `B` must be parsed again to resolve the new types added. 
While `C` is not required to be parsed again (it didn't change), the types provided by `C` must be made available when parsing `B`, and `B`'s types must be made available when parsing `C` and so forth.
