### PR TITLE
Revamp/provide example application

### DIFF
--- a/sbm-support-rewrite/pom.xml
+++ b/sbm-support-rewrite/pom.xml
@@ -112,11 +112,6 @@
         </dependency>
         <dependency>
             <groupId>org.openrewrite</groupId>
-            <artifactId>rewrite-java</artifactId>
-            <version>${rewrite.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.openrewrite</groupId>
             <artifactId>rewrite-java-17</artifactId>
             <version>${rewrite.version}</version>
         </dependency>
@@ -183,6 +178,17 @@
             <artifactId>commons-cli</artifactId>
             <version>1.4</version>
         </dependency>
+        <dependency>
+            <groupId>org.openrewrite.recipe</groupId>
+            <artifactId>rewrite-migrate-java</artifactId>
+            <version>2.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openrewrite.recipe</groupId>
+            <artifactId>rewrite-spring</artifactId>
+            <version>5.0.10</version>
+        </dependency>
+
 
         <dependency>
             <groupId>org.openrewrite.maven</groupId>

--- a/sbm-support-rewrite/src/test/java/org/springframework/sbm/example/BootUpgradeExample.java
+++ b/sbm-support-rewrite/src/test/java/org/springframework/sbm/example/BootUpgradeExample.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2021 - 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.sbm.example;
+
+import org.apache.commons.io.FileUtils;
+import org.openrewrite.Recipe;
+import org.openrewrite.SourceFile;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.sbm.parsers.ProjectScanner;
+import org.springframework.sbm.parsers.RewriteProjectParser;
+import org.springframework.sbm.parsers.RewriteProjectParsingResult;
+import org.springframework.sbm.project.resource.ProjectResourceSet;
+import org.springframework.sbm.project.resource.ProjectResourceSetFactory;
+import org.springframework.sbm.project.resource.ProjectResourceSetSerializer;
+import org.springframework.sbm.recipes.RewriteRecipeDiscovery;
+import org.springframework.sbm.test.util.GitTestHelper;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static java.util.stream.Collectors.joining;
+
+@SpringBootApplication
+public class BootUpgradeExample implements CommandLineRunner {
+
+    public static void main(String[] args) {
+        SpringApplication.run(BootUpgradeExample.class, args);
+    }
+
+    @Autowired
+    ProjectScanner scanner;
+    @Autowired
+    RewriteProjectParser parser;
+    @Autowired
+    RewriteRecipeDiscovery discovery;
+    @Autowired
+    ProjectResourceSetSerializer serializer;
+    @Autowired
+    ProjectResourceSetFactory factory;
+
+    @Override
+    public void run(String... args) throws Exception {
+
+        // Clone Spring PetClinic using Boot 2.7
+        String tmpDir = System.getProperty("java.io.tmpdir");
+        String target = tmpDir + "/cloned";
+        FileUtils.forceDelete(Path.of(target).toFile());
+        Path baseDir = GitTestHelper.cloneProjectCommit("https://github.com/spring-projects/spring-petclinic.git", target, "9ecdc1111e3da388a750ace41a125287d9620534");
+
+        // parse
+        RewriteProjectParsingResult parsingResult = parser.parse(baseDir);
+        List<SourceFile> sourceFiles = parsingResult.sourceFiles();
+
+        // create ProjectResourceSet
+        ProjectResourceSet projectResourceSet = factory.create(baseDir, sourceFiles);
+
+        // find recipe
+        String recipeName = "org.openrewrite.java.spring.boot3.UpgradeSpringBoot_3_1";
+        List<Recipe> recipes = discovery.discoverRecipes();
+        System.out.println("Discovered %d recipes.".formatted(recipes.size()));
+        Recipe recipe = recipes.stream().filter(r -> r.getName().equals(recipeName)).findFirst().get();
+
+        // apply recipe
+        System.out.println("Apply recipe '%s'".formatted(recipe.getName()));
+        projectResourceSet.apply(recipe);
+
+        // write changes to fs
+        serializer.writeChanges(projectResourceSet);
+    }
+
+}

--- a/sbm-support-rewrite/src/test/java/org/springframework/sbm/example/recipes/DummyRecipe.java
+++ b/sbm-support-rewrite/src/test/java/org/springframework/sbm/example/recipes/DummyRecipe.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.example.recipes;
+package org.springframework.sbm.example.recipes;
 
 import org.openrewrite.Recipe;
 

--- a/sbm-support-rewrite/src/test/java/org/springframework/sbm/parsers/RewriteRecipeDiscoveryTest.java
+++ b/sbm-support-rewrite/src/test/java/org/springframework/sbm/parsers/RewriteRecipeDiscoveryTest.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.sbm.parsers;
 
-import com.example.recipes.DummyRecipe;
+import org.springframework.sbm.example.recipes.DummyRecipe;
 import io.example.recipes.AnotherDummyRecipe;
 import org.assertj.core.data.Index;
 import org.jetbrains.annotations.NotNull;
@@ -79,17 +79,17 @@ class RewriteRecipeDiscoveryTest {
     void providingAcceptedPackagesShouldOnlyShowRecipesWithMatchingPackage() {
         ClasspathScanningLoader resourceLoader1 = new ClasspathScanningLoader(new Properties(), new String[]{"com.example"});
         Collection<Recipe> recipes = resourceLoader1.listRecipes();
-        assertThat(recipes).anyMatch(r -> com.example.recipes.DummyRecipe.class == r.getClass());
+        assertThat(recipes).anyMatch(r -> DummyRecipe.class == r.getClass());
         assertThat(recipes).noneMatch(r -> io.example.recipes.AnotherDummyRecipe.class == r.getClass());
 
         ClasspathScanningLoader resourceLoader2 = new ClasspathScanningLoader(new Properties(), new String[]{"io.example"});
         Collection<Recipe> recipes2 = resourceLoader2.listRecipes();
-        assertThat(recipes2).noneMatch(r -> com.example.recipes.DummyRecipe.class == r.getClass());
+        assertThat(recipes2).noneMatch(r -> DummyRecipe.class == r.getClass());
         assertThat(recipes2).anyMatch(r -> io.example.recipes.AnotherDummyRecipe.class == r.getClass());
 
         ClasspathScanningLoader resourceLoader3 = new ClasspathScanningLoader(new Properties(), new String[]{"io.example", "com.example"});
         Collection<Recipe> recipes3 = resourceLoader3.listRecipes();
-        assertThat(recipes3).anyMatch(r -> com.example.recipes.DummyRecipe.class == r.getClass());
+        assertThat(recipes3).anyMatch(r -> DummyRecipe.class == r.getClass());
         assertThat(recipes3).anyMatch(r -> io.example.recipes.AnotherDummyRecipe.class == r.getClass());
     }
 

--- a/sbm-support-rewrite/src/test/java/org/springframework/sbm/test/util/GitTestHelper.java
+++ b/sbm-support-rewrite/src/test/java/org/springframework/sbm/test/util/GitTestHelper.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 - 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sbm.test.util;
+
+import org.apache.commons.io.FileUtils;
+import org.jetbrains.annotations.NotNull;
+import org.openrewrite.shaded.jgit.api.Git;
+import org.openrewrite.shaded.jgit.api.errors.GitAPIException;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * @author Fabian Krüger
+ */
+public class GitTestHelper {
+
+    public static Path cloneProjectCommit(String url, String target, String commitHash) {
+        return checkout(url, target, commitHash);
+    }
+
+    public static Path cloneProjectTag(String url, String target, String tag) {
+        String ref = "refs/tags/" + tag;
+        return checkout(url, target, ref);
+    }
+
+    @NotNull
+    private static Path checkout(String url, String target, String ref) {
+        try {
+            File directory = Path.of(target).toFile();
+            if (!directory.exists()) {
+                FileUtils.forceMkdir(directory.toPath().toAbsolutePath().normalize().toFile());
+            }
+            Git git = Git.cloneRepository()
+                    .setDirectory(directory)
+                    .setURI(url)
+                    .call();
+
+            git.checkout()
+                     .setName(ref)
+                    .call();
+
+            return git.getRepository().getDirectory().toPath().getParent();
+        } catch (GitAPIException e) {
+            throw new RuntimeException(e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Adds [example Boot app](https://github.com/spring-projects-experimental/spring-boot-migrator/blob/faf353b0794a3f3f88ef126ce64f562764171c0a/sbm-support-rewrite/src/test/java/org/springframework/sbm/example/BootUpgradeExample.java#L41) running OpenRewrite's Spring Boot 3.1 Upgrade recipe against PetClinic.

- [x] Remove or find a better place for this example