### PR TITLE
Fix Rabbitmq definitions issue in mule migration demo

### DIFF
--- a/demos/demo-migrate-mule-to-boot/testcode/given/init/definitions.json
+++ b/demos/demo-migrate-mule-to-boot/testcode/given/init/definitions.json
@@ -1,4 +1,26 @@
 {
+  "users":[
+    {
+      "name":"guest",
+      "password_hash":"NnOJMfR7/f8OAs2T4vR6KUXNle/f7oBVifv7ksvqR7xtnnuX",
+      "hashing_algorithm":"rabbit_password_hashing_sha256",
+      "tags":"administrator"
+    }
+  ],
+  "vhosts":[
+    {
+      "name":"/"
+    }
+  ],
+  "permissions":[
+    {
+      "user":"guest",
+      "vhost":"/",
+      "configure":".*",
+      "write":".*",
+      "read":".*"
+    }
+  ],
   "queues": [
     {
       "name": "sales_queue",


### PR DESCRIPTION
Fix issue #1053 by:

- add virtual host `/`
- add `guest` user with password `guest` for Rabbitmq management page access
- add permission for user `guest`