### PR TITLE
Fix/1057 maven reactor root detection

### DIFF
--- a/applications/spring-shell/src/test/java/org/springframework/sbm/ScanProjectWithPersistenceXmlInTestResourcesIssue1010Test.java
+++ b/applications/spring-shell/src/test/java/org/springframework/sbm/ScanProjectWithPersistenceXmlInTestResourcesIssue1010Test.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 - 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sbm;
+
+import org.junit.jupiter.api.Test;
+
+class ScanProjectWithPersistenceXmlInTestResourcesIssue1010Test
+extends IntegrationTestBaseClass {
+
+    @Override
+    protected String getTestSubDir() {
+        return "project-with-persistence-xml-in-test-resources";
+    }
+
+    @Test
+    void scanAndMigrateJpaDoesNotFail() {
+
+        intializeTestProject();
+
+        executeMavenGoals(getTestDir(), "clean", "package");
+
+        // This step previously crashed with ResourceFilterException (#1010)
+        scanProject();
+
+        assertRecipeApplicable("migrate-jpa-to-spring-boot");
+
+        applyRecipe("migrate-jpa-to-spring-boot");
+    }
+}

--- a/components/sbm-core/src/main/java/org/springframework/sbm/build/api/ApplicationModules.java
+++ b/components/sbm-core/src/main/java/org/springframework/sbm/build/api/ApplicationModules.java
@@ -21,15 +21,12 @@ import org.springframework.sbm.build.impl.MavenBuildFileUtil;
 import org.springframework.sbm.build.impl.OpenRewriteMavenBuildFile;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /***
- * Represents all modules in the {@code ProjectCOntext}.
+ * Represents all modules in the {@code ProjectContext}.
  */
 public class ApplicationModules {
     private final List<Module> modules;
@@ -44,8 +41,7 @@ public class ApplicationModules {
 
     public Module getRootModule() {
         return modules.stream()
-                .filter(m -> m.getBuildFile().isRootBuildFile())
-                .findFirst()
+                .min(RootBuildFileSelector.rootModuleComparator())
                 .orElseThrow(() -> new RootBuildFileNotFoundException("Module with root build file is missing"));
     }
 
@@ -89,8 +85,8 @@ public class ApplicationModules {
     }
 
     /**
-    * Takes a list of {@code MavenResolutionResult}s and returns the modules with matching {@code groupId:artifactId}.
-    */
+     * Takes a list of {@code MavenResolutionResult}s and returns the modules with matching {@code groupId:artifactId}.
+     */
     @NotNull
     private List<Module> getModulesContainingMavens(List<MavenResolutionResult> mavens) {
         List<String> relevantGroupAndArtifactIds = mavens.stream()
@@ -112,12 +108,10 @@ public class ApplicationModules {
      */
     public List<Module> getTopmostApplicationModules() {
         List<Module> topmostModules = new ArrayList<>();
-        Set<String> packagingTypes = Set.of("jar","war","mule-application");
+        Set<String> packagingTypes = Set.of("jar", "war", "mule-application");
         modules.forEach(module -> {
             if (packagingTypes.contains(module.getBuildFile().getPackaging())) {
-                // no other pom depends on this pom in its dependency section
                 if (noOtherPomDependsOn(module.getBuildFile())) {
-                    // has no parent or parent has packaging pom
                     Optional<ParentDeclaration> parentPomDeclaration = module.getBuildFile().getParentPomDeclaration();
                     if (parentPomDeclaration.isEmpty()) {
                         topmostModules.add(module);
@@ -144,7 +138,7 @@ public class ApplicationModules {
     }
 
     private boolean isDependencyOfAnotherModule(Module applicationModule) {
-        return ! noOtherPomDependsOn(applicationModule.getBuildFile());
+        return !noOtherPomDependsOn(applicationModule.getBuildFile());
     }
 
     private boolean isPackagingOfPom(ParentDeclaration parentPomDeclaration) {
@@ -165,11 +159,11 @@ public class ApplicationModules {
 
     private boolean noOtherPomDependsOn(BuildFile buildFile) {
         return !this.modules.stream()
-                .anyMatch(module -> module.getBuildFile().getRequestedDependencies().stream().anyMatch(d -> d.getCoordinates().equals(buildFile.getCoordinates())));
+                .anyMatch(module -> module.getBuildFile().getRequestedDependencies().stream()
+                        .anyMatch(d -> d.getCoordinates().equals(buildFile.getCoordinates())));
     }
 
     public boolean isSingleModuleApplication() {
         return modules.size() == 1;
     }
-
 }

--- a/components/sbm-core/src/main/java/org/springframework/sbm/build/api/RootBuildFileFilter.java
+++ b/components/sbm-core/src/main/java/org/springframework/sbm/build/api/RootBuildFileFilter.java
@@ -15,17 +15,25 @@
  */
 package org.springframework.sbm.build.api;
 
+import org.jetbrains.annotations.NotNull;
 import org.springframework.sbm.project.resource.ProjectResourceSet;
 import org.springframework.sbm.project.resource.filter.ProjectResourceFinder;
 
+import java.util.List;
+
 public class RootBuildFileFilter implements ProjectResourceFinder<BuildFile> {
+
     @Override
-    public BuildFile apply(ProjectResourceSet projectResourceSet) {
-        return projectResourceSet.stream()
-                .filter(pr -> BuildFile.class.isAssignableFrom(pr.getClass()))
+    public BuildFile apply(@NotNull ProjectResourceSet projectResourceSet) {
+        List<BuildFile> buildFiles = projectResourceSet.stream()
+                .filter(BuildFile.class::isInstance)
                 .map(BuildFile.class::cast)
-                .filter(bf -> bf.isRootBuildFile())
-                .findFirst()
-                .orElseThrow(() -> new RootBuildFileNotFoundException("Could not find BuildFile for root module."));
+                .toList();
+
+        if (buildFiles.isEmpty()) {
+            throw new RootBuildFileNotFoundException("Could not find BuildFile for root module.");
+        }
+
+        return RootBuildFileSelector.selectRootBuildFile(buildFiles);
     }
 }

--- a/components/sbm-core/src/main/java/org/springframework/sbm/build/api/RootBuildFileSelector.java
+++ b/components/sbm-core/src/main/java/org/springframework/sbm/build/api/RootBuildFileSelector.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2021 - 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.sbm.build.api;
+
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Shared logic for selecting the reactor root build file.
+ *
+ * <p>This heuristic is used by both {@link RootBuildFileFilter}
+ * and {@link ApplicationModules} to ensure consistent root detection.
+ *
+ * <p><b>Ranking priority (ascending = stronger candidate):</b>
+ * <ol>
+ *   <li>Explicitly flagged as root ({@code isRootBuildFile() == true})</li>
+ *   <li>Aggregator POM ({@code packaging=pom} AND non-empty {@code <modules>})</li>
+ *   <li>Plain POM ({@code packaging=pom})</li>
+ *   <li>Everything else (jar, war, etc.)</li>
+ * </ol>
+ *
+ * <p>Within the same category:
+ * <ul>
+ *   <li>Shallower paths win (closer to project root)</li>
+ *   <li>Lexical path comparison ensures deterministic selection</li>
+ * </ul>
+ *
+ * <p><b>Caveat:</b>
+ * If parsing fails to resolve {@code <modules>} (e.g. partial scan failure),
+ * the aggregator heuristic cannot trigger. In that case the selection
+ * degrades gracefully to:
+ *
+ * <pre>
+ * pom packaging → shallowest path → lexical tie-break
+ * </pre>
+ */
+final class RootBuildFileSelector {
+
+    private RootBuildFileSelector() {}
+
+    /*
+     * ===============================
+     *  Public selection entry points
+     * ===============================
+     */
+
+    static BuildFile selectRootBuildFile(List<BuildFile> buildFiles) {
+        return buildFiles.stream()
+                .min(ROOT_BUILD_FILE_COMPARATOR)
+                .orElseThrow(() ->
+                        new RootBuildFileNotFoundException("Could not find BuildFile for root module."));
+    }
+
+    static Comparator<BuildFile> rootComparator() {
+        return ROOT_BUILD_FILE_COMPARATOR;
+    }
+
+    static Comparator<Module> rootModuleComparator() {
+        return ROOT_MODULE_COMPARATOR;
+    }
+
+    /*
+     * ===============================
+     *  Comparator definitions
+     * ===============================
+     */
+
+    private static final Comparator<BuildFile> ROOT_BUILD_FILE_COMPARATOR =
+            Comparator.comparingInt(RootBuildFileSelector::score)
+                    .thenComparingInt(bf -> pathDepth(bf.getSourcePath()))
+                    .thenComparing(bf -> bf.getSourcePath() == null ? "" : bf.getSourcePath().toString());
+
+    /**
+     * Derives module ordering directly from the BuildFile comparator,
+     * preventing drift if ranking rules evolve.
+     */
+    private static final Comparator<Module> ROOT_MODULE_COMPARATOR =
+            Comparator.comparing(Module::getBuildFile, ROOT_BUILD_FILE_COMPARATOR);
+
+    /*
+     * ===============================
+     *  Ranking heuristic
+     * ===============================
+     */
+
+    /**
+     * Lower score = stronger root candidate.
+     */
+    static int score(BuildFile bf) {
+        if (bf.isRootBuildFile()) {
+            return 0;
+        }
+
+        boolean isPom = "pom".equals(safeLower(bf.getPackaging()));
+        if (!isPom) {
+            return 3;
+        }
+
+        boolean isAggregator = false;
+        try {
+            List<String> modules = bf.getDeclaredModules();
+            isAggregator = modules != null && !modules.isEmpty();
+        } catch (UnsupportedOperationException ignored) {
+            // Non-Maven BuildFile implementations may not support this.
+            // Treat as non-aggregator POM.
+        }
+
+        return isAggregator ? 1 : 2;
+    }
+
+    /*
+     * ===============================
+     *  Helpers
+     * ===============================
+     */
+
+    static int pathDepth(Path path) {
+        return path == null ? Integer.MAX_VALUE : path.getNameCount();
+    }
+
+    private static String safeLower(String s) {
+        return s == null ? "" : s.toLowerCase(Locale.ROOT);
+    }
+}

--- a/components/sbm-core/src/test/java/org/springframework/sbm/build/api/ApplicationModulesTest.java
+++ b/components/sbm-core/src/test/java/org/springframework/sbm/build/api/ApplicationModulesTest.java
@@ -23,82 +23,86 @@ import org.springframework.sbm.project.resource.TestProjectContext;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class ApplicationModulesTest {
 
     private static ApplicationModules sut;
+
     @Language("xml")
     private static final String PARENT_POM = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0"
-                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-                    <modelVersion>4.0.0</modelVersion>
+            <?xml version="1.0" encoding="UTF-8"?>
+            <project xmlns="http://maven.apache.org/POM/4.0.0"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>org.example</groupId>
+                <artifactId>parent</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <packaging>pom</packaging>
+                <properties>
+                    <maven.compiler.source>17</maven.compiler.source>
+                    <maven.compiler.target>17</maven.compiler.target>
+                </properties>
+                <modules>
+                    <module>module1</module>
+                    <module>module2</module>
+                </modules>
+            </project>
+            """;
+
+    @Language("xml")
+    private static final String APPLICATION_POM = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <project xmlns="http://maven.apache.org/POM/4.0.0"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <parent>
                     <groupId>org.example</groupId>
                     <artifactId>parent</artifactId>
                     <version>1.0-SNAPSHOT</version>
-                    <packaging>pom</packaging>
-                    <properties>
-                        <maven.compiler.source>17</maven.compiler.source>
-                        <maven.compiler.target>17</maven.compiler.target>
-                    </properties>
-                    <modules>
-                        <module>module1</module>
-                        <module>module2</module>
-                    </modules>
-                </project>
-                """;
-    @Language("xml")
-    private static final String APPLICATION_POM = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0"
-                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-                    <modelVersion>4.0.0</modelVersion>
-                    <parent>
+                    <relativePath>../pom.xml</relativePath>
+                </parent>
+                <artifactId>module1</artifactId>
+                <properties>
+                    <maven.compiler.source>17</maven.compiler.source>
+                    <maven.compiler.target>17</maven.compiler.target>
+                </properties>
+                <dependencies>
+                    <dependency>
                         <groupId>org.example</groupId>
-                        <artifactId>parent</artifactId>
-                        <version>1.0-SNAPSHOT</version>
-                        <relativePath>../pom.xml</relativePath>
-                    </parent>
-                    <artifactId>module1</artifactId>
-                    <properties>
-                        <maven.compiler.source>17</maven.compiler.source>
-                        <maven.compiler.target>17</maven.compiler.target>
-                    </properties>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.example</groupId>
-                            <artifactId>module2</artifactId>
-                            <version>${project.version}</version>
-                        </dependency>
-                    </dependencies>
-                </project>
-                """;
+                        <artifactId>module2</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
+            </project>
+            """;
+
     @Language("xml")
     private static final String COMPONENT_POM = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project xmlns="http://maven.apache.org/POM/4.0.0"
-                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-                    <modelVersion>4.0.0</modelVersion>
-                    <parent>
-                        <groupId>org.example</groupId>
-                        <artifactId>parent</artifactId>
-                        <version>1.0-SNAPSHOT</version>
-                        <relativePath>../pom.xml</relativePath>
-                    </parent>
-                    <artifactId>module2</artifactId>
-                    <properties>
-                        <maven.compiler.source>17</maven.compiler.source>
-                        <maven.compiler.target>17</maven.compiler.target>
-                    </properties>
-                </project>
-                """;
+            <?xml version="1.0" encoding="UTF-8"?>
+            <project xmlns="http://maven.apache.org/POM/4.0.0"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                <modelVersion>4.0.0</modelVersion>
+                <parent>
+                    <groupId>org.example</groupId>
+                    <artifactId>parent</artifactId>
+                    <version>1.0-SNAPSHOT</version>
+                    <relativePath>../pom.xml</relativePath>
+                </parent>
+                <artifactId>module2</artifactId>
+                <properties>
+                    <maven.compiler.source>17</maven.compiler.source>
+                    <maven.compiler.target>17</maven.compiler.target>
+                </properties>
+            </project>
+            """;
 
     @BeforeAll
     static void beforeAll() {
@@ -110,6 +114,68 @@ class ApplicationModulesTest {
                 .build()
                 .getApplicationModules();
     }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    /**
+     * Creates a mock Module whose BuildFile stubs all fields consulted by
+     * RootBuildFileSelector.score(): isRootBuildFile, getSourcePath,
+     * getPackaging, and getDeclaredModules.
+     *
+     * Previously the helper only stubbed isRootBuildFile + getSourcePath,
+     * which caused getPackaging/getDeclaredModules to return null and pushed
+     * every module to score 3 (non-POM fallback). Tests passed but for the
+     * wrong reason — the aggregator/plain-POM scoring paths were never reached.
+     */
+    private static Module moduleWithPom(String sourcePath,
+                                        boolean isRoot,
+                                        String packaging,
+                                        List<String> declaredModules) {
+        BuildFile buildFile = mock(BuildFile.class);
+        when(buildFile.isRootBuildFile()).thenReturn(isRoot);
+        when(buildFile.getSourcePath()).thenReturn(Path.of(sourcePath));
+        when(buildFile.getPackaging()).thenReturn(packaging);
+        when(buildFile.getDeclaredModules()).thenReturn(declaredModules);
+
+        Module module = mock(Module.class);
+        when(module.getBuildFile()).thenReturn(buildFile);
+        return module;
+    }
+
+    /** Convenience overload: plain-POM module, not explicitly marked as root. */
+    private static Module pomModule(String sourcePath, List<String> declaredModules) {
+        return moduleWithPom(sourcePath, false, "pom", declaredModules);
+    }
+
+    /** Convenience overload: jar module, not explicitly marked as root. */
+    private static Module jarModule(String sourcePath) {
+        return moduleWithPom(sourcePath, false, "jar", List.of());
+    }
+
+    /**
+     * Creates a mock Module for getTopmostApplicationModules / getComponentModules tests.
+     *
+     * getRequestedDependencies() is deliberately empty to avoid exercising the
+     * coordinate-matching path inside noOtherPomDependsOn(). getCoordinates() is
+     * stubbed anyway so the mock stays robust if a future change adds dependencies
+     * to this helper.
+     */
+    private static Module moduleWithPackaging(String packaging) {
+        BuildFile buildFile = mock(BuildFile.class);
+        when(buildFile.getPackaging()).thenReturn(packaging);
+        // Deliberately empty: avoids exercising dependency coordinate matching
+        // in noOtherPomDependsOn(). If dependencies are ever added here,
+        // getCoordinates() below ensures the mock won't throw unexpectedly.
+        when(buildFile.getRequestedDependencies()).thenReturn(List.of());
+        when(buildFile.getCoordinates()).thenReturn("org.example:dummy:1.0");
+        when(buildFile.getParentPomDeclaration()).thenReturn(Optional.empty());
+
+        Module module = mock(Module.class);
+        when(module.getBuildFile()).thenReturn(buildFile);
+        return module;
+    }
+
+    // ── integration tests (TestProjectContext) ────────────────────────────────
 
     @Test
     void shouldBeRecognizedAsMultiModuleProject() {
@@ -131,7 +197,8 @@ class ApplicationModulesTest {
     void shouldNotFindRootModuleForMissingRootBuildFile() {
         ApplicationModules applicationModules = new ApplicationModules(List.of());
 
-        assertThatThrownBy(applicationModules::getRootModule).isInstanceOf(RootBuildFileNotFoundException.class);
+        assertThatThrownBy(applicationModules::getRootModule)
+                .isInstanceOf(RootBuildFileNotFoundException.class);
     }
 
     @Test
@@ -157,11 +224,115 @@ class ApplicationModulesTest {
     @Test
     void componentModule() {
         assertThat(sut.getComponentModules()).hasSize(1);
-        Module applicationModule = sut.getTopmostApplicationModules().get(0);
-        assertThat(applicationModule.getModulePath()).isEqualTo(Path.of("module1"));
-        assertThat(applicationModule.getBuildFile().getCoordinates()).isEqualTo("org.example:module1:1.0-SNAPSHOT");
+        Module componentModule = sut.getComponentModules().get(0);
+        assertThat(componentModule.getModulePath()).isEqualTo(Path.of("module2"));
+        assertThat(componentModule.getBuildFile().getCoordinates()).isEqualTo("org.example:module2:1.0-SNAPSHOT");
     }
 
-    // TODO: add test for getTopmostApplicationModules with packaging != jar
+    // ── unit tests: getRootModule fallback logic (Mockito) ────────────────────
 
+    @Test
+    void getRootModule_fallback_choosesShallowerPom_whenNoneMarkedAsRoot() {
+        // Both are plain POMs with no declared modules; depth decides.
+        Module parent = pomModule("parent/pom.xml", List.of());
+        Module child  = pomModule("parent/module/pom.xml", List.of());
+
+        Module root = new ApplicationModules(List.of(parent, child)).getRootModule();
+
+        assertThat(root.getBuildFile().getSourcePath())
+                .isEqualTo(Path.of("parent/pom.xml"));
+    }
+
+    @Test
+    void getRootModule_explicitRoot_takesPriority_overShallowerPath() {
+        // Explicit flag beats depth — deeper module wins when it is marked as root.
+        Module shallower  = pomModule("parent/pom.xml", List.of());
+        Module markedRoot = moduleWithPom("parent/module/pom.xml", true, "pom", List.of());
+
+        Module root = new ApplicationModules(List.of(shallower, markedRoot)).getRootModule();
+
+        assertThat(root.getBuildFile().getSourcePath())
+                .isEqualTo(Path.of("parent/module/pom.xml"));
+    }
+
+    @Test
+    void getRootModule_aggregatorPom_beatsPlainPomAtSameDepth() {
+        // repo/pom.xml and parent/pom.xml are at the same depth (2 name components).
+        // The aggregator score (1) must beat the plain-POM score (2) — not depth.
+        Module plainPom      = pomModule("repo/pom.xml",   List.of());
+        Module aggregatorPom = pomModule("parent/pom.xml", List.of("module-a"));
+        Module jar           = jarModule("module-a/pom.xml");
+
+        Module root = new ApplicationModules(List.of(plainPom, aggregatorPom, jar)).getRootModule();
+
+        assertThat(root.getBuildFile().getSourcePath())
+                .isEqualTo(Path.of("parent/pom.xml"));
+    }
+
+    @Test
+    void getRootModule_aggregatorPom_beatsJarAtAnyDepth() {
+        // An aggregator POM deeper than a jar module still wins on score alone.
+        Module deepAggregator = pomModule("a/b/pom.xml", List.of("module-a"));
+        Module shallowJar     = jarModule("app/pom.xml");
+
+        Module root = new ApplicationModules(List.of(shallowJar, deepAggregator)).getRootModule();
+
+        assertThat(root.getBuildFile().getSourcePath())
+                .isEqualTo(Path.of("a/b/pom.xml"));
+    }
+
+    @Test
+    void getRootModule_depthBreaksTie_betweenTwoAggregators() {
+        // Both are aggregator POMs; the shallower one should win.
+        Module shallowAggregator = pomModule("parent/pom.xml",       List.of("child"));
+        Module deepAggregator    = pomModule("parent/child/pom.xml", List.of("grandchild"));
+
+        Module root = new ApplicationModules(List.of(deepAggregator, shallowAggregator)).getRootModule();
+
+        assertThat(root.getBuildFile().getSourcePath())
+                .isEqualTo(Path.of("parent/pom.xml"));
+    }
+
+    @Test
+    void getRootModule_unsupportedOperationOnDeclaredModules_treatedAsPlainPom() {
+        // Simulates a non-Maven BuildFile that throws UnsupportedOperationException
+        // from getDeclaredModules(). The selector must not propagate the exception
+        // and must fall back to treating the file as a plain POM (score 2).
+        BuildFile unsupportedBf = mock(BuildFile.class);
+        when(unsupportedBf.isRootBuildFile()).thenReturn(false);
+        when(unsupportedBf.getSourcePath()).thenReturn(Path.of("parent/pom.xml"));
+        when(unsupportedBf.getPackaging()).thenReturn("pom");
+        when(unsupportedBf.getDeclaredModules()).thenThrow(new UnsupportedOperationException("not supported"));
+
+        Module unsupported = mock(Module.class);
+        when(unsupported.getBuildFile()).thenReturn(unsupportedBf);
+
+        // A jar build file scores 3; the plain-POM fallback (score 2) must win.
+        Module deepJar = jarModule("parent/module/pom.xml");
+
+        Module root = new ApplicationModules(List.of(unsupported, deepJar)).getRootModule();
+
+        assertThat(root.getBuildFile().getSourcePath())
+                .isEqualTo(Path.of("parent/pom.xml"));
+    }
+
+    // ── unit tests: getTopmostApplicationModules packaging filter ───
+
+    @Test
+    void getTopmostApplicationModules_ignoresPomPackaging_asApplicationModule() {
+        // A module with pom packaging is never an application module.
+        Module pomModule = moduleWithPackaging("pom");
+        ApplicationModules am = new ApplicationModules(List.of(pomModule));
+
+        assertThat(am.getTopmostApplicationModules()).isEmpty();
+    }
+
+    @Test
+    void getTopmostApplicationModules_includesWarPackaging() {
+        // war packaging must be treated the same as jar for application module detection.
+        Module warModule = moduleWithPackaging("war");
+        ApplicationModules am = new ApplicationModules(List.of(warModule));
+
+        assertThat(am.getTopmostApplicationModules()).containsExactly(warModule);
+    }
 }

--- a/components/sbm-core/src/test/java/org/springframework/sbm/build/api/RootBuildFileFilterTest.java
+++ b/components/sbm-core/src/test/java/org/springframework/sbm/build/api/RootBuildFileFilterTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2021 - 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sbm.build.api;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.*;
+import org.openrewrite.marker.Markers;
+import org.springframework.sbm.project.resource.ProjectResourceSet;
+import org.springframework.sbm.project.resource.RewriteSourceFileHolder;
+
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RootBuildFileFilterTest {
+
+    /**
+     * Minimal BuildFile stub for filter tests.
+     * Only the parts relevant to root selection are configurable.
+     */
+    static class PomStub extends RewriteSourceFileHolder<SourceFile> implements BuildFile {
+
+        private final boolean isRoot;
+        private final String packaging;
+        private final List<String> declaredModules;
+        private final boolean declaredModulesUnsupported;
+
+        PomStub(String sourcePath,
+                boolean isRoot,
+                String packaging,
+                List<String> declaredModules) {
+            this(sourcePath, isRoot, packaging, declaredModules, false);
+        }
+
+        PomStub(String sourcePath,
+                boolean isRoot,
+                String packaging,
+                List<String> declaredModules,
+                boolean declaredModulesUnsupported) {
+            super(Path.of(".").toAbsolutePath(), stubSourceFile(Path.of(sourcePath)));
+            this.isRoot = isRoot;
+            this.packaging = packaging;
+            this.declaredModules = declaredModules;
+            this.declaredModulesUnsupported = declaredModulesUnsupported;
+        }
+
+        private static SourceFile stubSourceFile(Path sourcePath) {
+            return new SourceFile() {
+                @Override public Path getSourcePath() { return sourcePath; }
+                @Override public <T extends SourceFile> T withSourcePath(Path p) { return null; }
+                @Override public UUID getId() { return UUID.randomUUID(); }
+                @Override public Markers getMarkers() { return Markers.EMPTY; }
+                @Override public <T extends Tree> T withId(UUID id) { return null; }
+                @Override public <P> boolean isAcceptable(TreeVisitor<?, P> v, P p) { return false; }
+                @Override public SourceFile withMarkers(Markers m) { return this; }
+                @Override public Charset getCharset() { return null; }
+                @Override public <T extends SourceFile> T withCharset(Charset c) { return null; }
+                @Override public boolean isCharsetBomMarked() { return false; }
+                @Override public <T extends SourceFile> T withCharsetBomMarked(boolean b) { return null; }
+                @Override public Checksum getChecksum() { return null; }
+                @Override public <T extends SourceFile> T withChecksum(Checksum c) { return null; }
+                @Override public FileAttributes getFileAttributes() { return null; }
+                @Override public <T extends SourceFile> T withFileAttributes(FileAttributes f) { return null; }
+            };
+        }
+
+        @Override public boolean isRootBuildFile() { return isRoot; }
+
+        @Override public String getPackaging() { return packaging; }
+
+        @Override
+        public List<String> getDeclaredModules() {
+            if (declaredModulesUnsupported) {
+                throw new UnsupportedOperationException("declaredModules not supported");
+            }
+            return declaredModules == null ? List.of() : declaredModules;
+        }
+
+        // ── BuildFile contract: no-ops, not relevant for this test ──────────
+        @Override public List<Dependency> getDeclaredDependencies(org.openrewrite.maven.tree.Scope... s) { return List.of(); }
+        @Override public List<Dependency> getRequestedDependencies() { return List.of(); }
+        @Override public Set<Dependency> getEffectiveDependencies(org.openrewrite.maven.tree.Scope s) { return Set.of(); }
+        @Override public Set<Dependency> getEffectiveDependencies() { return Set.of(); }
+        @Override public boolean hasDeclaredDependencyMatchingRegex(String... p) { return false; }
+        @Override public boolean hasEffectiveDependencyMatchingRegex(String... p) { return false; }
+        @Override public boolean hasExactDeclaredDependency(Dependency d) { return false; }
+        @Override public void addDependency(Dependency d) {}
+        @Override public void addDependencies(List<Dependency> d) {}
+        @Override public void removeDependencies(List<Dependency> d) {}
+        @Override public void removeDependenciesMatchingRegex(String... r) {}
+        @Override public void removeDependenciesInner(List<Dependency> d) {}
+        @Override public List<Dependency> getEffectiveDependencyManagement() { return List.of(); }
+        @Override public List<Dependency> getRequestedDependencyManagement() { return List.of(); }
+        @Override public List<Dependency> getRequestedManagedDependencies() { return List.of(); }
+        @Override public void addToDependencyManagement(Dependency d) {}
+        @Override public void addToDependencyManagementInner(Dependency d) {}
+        @Override public List<Path> getResolvedDependenciesPaths() { return List.of(); }
+        @Override public boolean hasPlugin(Plugin p) { return false; }
+        @Override public void addPlugin(Plugin p) {}
+        @Override public List<Path> getClasspath() { return List.of(); }
+        @Override public List<Path> getSourceFolders() { return List.of(); }
+        @Override public List<Path> getTestSourceFolders() { return List.of(); }
+        @Override public List<Path> getResourceFolders() { return List.of(); }
+        @Override public List<Path> getTestResourceFolders() { return List.of(); }
+        @Override public Path getTestResourceFolder() { return null; }
+        @Override public Path getMainResourceFolder() { return null; }
+        @Override public void setProperty(String k, String v) {}
+        @Override public String getProperty(String k) { return ""; }
+        @Override public void deleteProperty(String k) {}
+        @Override public void setPackaging(String p) {}
+        @Override public List<Plugin> getPlugins() { return List.of(); }
+        @Override public void removePluginsMatchingRegex(String... r) {}
+        @Override public void removePlugins(String... c) {}
+        @Override public String getGroupId() { return ""; }
+        @Override public String getArtifactId() { return ""; }
+        @Override public String getVersion() { return ""; }
+        @Override public String getCoordinates() { return ""; }
+        @Override public boolean hasParent() { return false; }
+        @Override public void upgradeParentVersion(String v) {}
+        @Override public Optional<ParentDeclaration> getParentPomDeclaration() { return Optional.empty(); }
+        @Override public Optional<String> getName() { return Optional.empty(); }
+        @Override public void excludeDependencies(List<Dependency> d) {}
+        @Override public void addRepository(RepositoryDefinition r) {}
+        @Override public void addPluginRepository(RepositoryDefinition r) {}
+        @Override public List<RepositoryDefinition> getRepositories() { return List.of(); }
+        @Override public List<RepositoryDefinition> getPluginRepositories() { return List.of(); }
+        @Override public Optional<Plugin> findPlugin(String g, String a) { return Optional.empty(); }
+    }
+
+    @Test
+    void fallback_choosesShallowestPom_whenNoneMarkedAsRoot() {
+        ProjectResourceSet prs = new ProjectResourceSet(List.of(
+                new PomStub("parent/pom.xml",        false, "pom", List.of()),
+                new PomStub("parent/module/pom.xml", false, "pom", List.of())
+        ));
+
+        assertThat(new RootBuildFileFilter().apply(prs).getSourcePath())
+                .isEqualTo(Path.of("parent/pom.xml"));
+    }
+
+    @Test
+    void explicitRoot_takesPriority_overShallowerPath() {
+        ProjectResourceSet prs = new ProjectResourceSet(List.of(
+                new PomStub("parent/pom.xml",        false, "pom", List.of()),
+                new PomStub("parent/module/pom.xml", true,  "pom", List.of())
+        ));
+
+        assertThat(new RootBuildFileFilter().apply(prs).getSourcePath())
+                .isEqualTo(Path.of("parent/module/pom.xml"));
+    }
+
+    @Test
+    void aggregatorPom_wins_over_plainPom_whenDepthIsEqual() {
+        // Both candidates have equal depth (3); scoring must decide — aggregator (1) > plain POM (2).
+        ProjectResourceSet prs = new ProjectResourceSet(List.of(
+                new PomStub("parent/a/pom.xml", false, "pom", List.of()),           // plain POM,      depth 3
+                new PomStub("parent/b/pom.xml", false, "pom", List.of("module1"))   // aggregator POM, depth 3
+        ));
+
+        assertThat(new RootBuildFileFilter().apply(prs).getSourcePath())
+                .isEqualTo(Path.of("parent/b/pom.xml"));
+    }
+
+    @Test
+    void pom_wins_over_jar_even_ifJarIsShallower() {
+        // JAR is genuinely shallower (depth 2) than the POM candidate (depth 3),
+        // but semantic score takes priority over path depth: POM (2) beats JAR (3).
+        ProjectResourceSet prs = new ProjectResourceSet(List.of(
+                new PomStub("module/pom.xml",   false, "jar", List.of()),   // depth 2 — shallower but non-POM
+                new PomStub("parent/a/pom.xml", false, "pom", List.of())    // depth 3 — deeper but POM
+        ));
+
+        assertThat(new RootBuildFileFilter().apply(prs).getSourcePath())
+                .isEqualTo(Path.of("parent/a/pom.xml"));
+    }
+}


### PR DESCRIPTION
Fix root build file detection for Maven reactor projects.

Introduce RootBuildFileSelector to rank candidates by:

explicit root → aggregator POM → plain POM → other, with depth and lexical tie-breaking.

Used by RootBuildFileFilter and ApplicationModules to ensure consistent selection.

Adds tests for aggregator precedence, POM vs JAR, depth tie-breaking, and war packaging.

Fixes #1057