### PR TITLE
feat: Migrate JPA to Spring Boot - Remove unitName attribute from @PersistenceContext annotations to use the default persistence unit

### DIFF
--- a/.github/workflows/build-sbm-legacy.yml
+++ b/.github/workflows/build-sbm-legacy.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: 17

--- a/.github/workflows/build-sbm-legacy.yml
+++ b/.github/workflows/build-sbm-legacy.yml
@@ -25,3 +25,9 @@ jobs:
 
       - name: Maven Build
         run: ./mvnw --batch-mode clean package
+
+      - name: Upload JAR
+        uses: actions/upload-artifact@v4
+        with:
+          name: spring-boot-migrator
+          path: applications/spring-shell/target/spring-boot-migrator.jar

--- a/README.adoc
+++ b/README.adoc
@@ -37,8 +37,8 @@ ____
 
 == Documentation
 
-- https://github.com/spring-projects-experimental/spring-boot-migrator/blob/main/docs/reference/user-documentation.adoc[User documentation]
-- https://github.com/spring-projects-experimental/spring-boot-migrator/blob/main/docs/reference/developer-documentation.adoc[Developer documentation]
+- https://github.com/dojcsak/spring-boot-migrator/blob/main/docs/reference/user-documentation.adoc[User documentation]
+- https://github.com/dojcsak/spring-boot-migrator/blob/main/docs/reference/developer-documentation.adoc[Developer documentation]
 
 
 == Spring Boot 3.0 Upgrade - Interactive Web UI
@@ -53,7 +53,7 @@ endif::[]
 === Try the Spring Boot Upgrade Tool
 NOTE: **Use JDK 17**
 
-. Download the https://github.com/spring-projects-experimental/spring-boot-migrator/releases/latest/download/spring-boot-upgrade.jar[spring-boot-upgrade.jar]
+. Download the https://github.com/dojcsak/spring-boot-migrator/releases/latest/download/spring-boot-upgrade.jar[spring-boot-upgrade.jar]
 . Run `java -jar --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED spring-boot-upgrade.jar <path-to-application>`
 
 If any of your applications is on 2.7 and uses Maven (Gradle is currently not supported), we'd be happy if you

--- a/components/sbm-core/src/main/java/org/springframework/sbm/java/api/Annotation.java
+++ b/components/sbm-core/src/main/java/org/springframework/sbm/java/api/Annotation.java
@@ -32,4 +32,6 @@ public interface Annotation {
     boolean hasAttribute(String timeout);
 
     void setAttribute(String attribute, Object value, Class valueType);
+
+    void removeAttribute(String attribute);
 }

--- a/components/sbm-core/src/main/java/org/springframework/sbm/java/impl/OpenRewriteAnnotation.java
+++ b/components/sbm-core/src/main/java/org/springframework/sbm/java/impl/OpenRewriteAnnotation.java
@@ -84,6 +84,11 @@ public class OpenRewriteAnnotation implements Annotation {
     }
 
     @Override
+    public void removeAttribute(String attribute) {
+        refactoring.refactor(new RemoveAnnotationAttributeRecipe(getFullyQualifiedName(), attribute));
+    }
+
+    @Override
     public String toString() {
         return "OpenRewriteAnnotation(" + wrapped.print() + ")";
     }

--- a/components/sbm-core/src/main/java/org/springframework/sbm/java/impl/RemoveAnnotationAttributeRecipe.java
+++ b/components/sbm-core/src/main/java/org/springframework/sbm/java/impl/RemoveAnnotationAttributeRecipe.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2021 - 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.sbm.java.impl;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.jetbrains.annotations.NotNull;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.TypeUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class RemoveAnnotationAttributeRecipe extends Recipe {
+
+    String annotationType;
+    String attributeName;
+
+    @Override
+    public @NotNull String getDisplayName() {
+        return "Remove annotation attribute";
+    }
+
+    @Override
+    public @NotNull String getDescription() {
+        return "Removes an attribute from a matching annotation.";
+    }
+
+    @Override
+    public @NotNull TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.@NotNull Annotation visitAnnotation(J.@NotNull Annotation annotation, @NotNull ExecutionContext ctx) {
+                J.Annotation a = super.visitAnnotation(annotation, ctx);
+
+                if (!matchesAnnotationType(a, annotationType)) {
+                    return a;
+                }
+
+                List<Expression> args = a.getArguments();
+                if (args == null || args.isEmpty()) {
+                    return a;
+                }
+
+                List<Expression> filtered = new ArrayList<>();
+                for (Expression expr : args) {
+                    if (!isTargetAttribute(expr, attributeName)) {
+                        filtered.add(expr);
+                    }
+                }
+
+                if (filtered.size() == args.size()) {
+                    return a;
+                }
+
+                return a.withArguments(filtered.isEmpty() ? null : filtered);
+            }
+
+            private boolean matchesAnnotationType(J.Annotation annotation, String expectedFqn) {
+                var type = TypeUtils.asFullyQualified(annotation.getAnnotationType().getType());
+                return type != null && expectedFqn.equals(type.getFullyQualifiedName());
+            }
+
+            private boolean isTargetAttribute(Expression expr, String attributeName) {
+                if (expr instanceof J.Assignment assignment) {
+                    if (assignment.getVariable() instanceof J.Identifier ident) {
+                        return attributeName.equals(ident.getSimpleName());
+                    }
+                    return false;
+                }
+
+                return "value".equals(attributeName);
+            }
+        };
+    }
+}

--- a/components/sbm-recipes-boot-upgrade/src/test/java/org/springframework/sbm/boot/upgrade_27_30/checks/ApacheSolrRepositoryBeanFinderTest.java
+++ b/components/sbm-recipes-boot-upgrade/src/test/java/org/springframework/sbm/boot/upgrade_27_30/checks/ApacheSolrRepositoryBeanFinderTest.java
@@ -17,6 +17,7 @@ package org.springframework.sbm.boot.upgrade_27_30.checks;
 
 
 import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.sbm.engine.context.ProjectContext;
 import org.springframework.sbm.java.api.JavaSourceAndType;
@@ -27,6 +28,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Disabled
 public class ApacheSolrRepositoryBeanFinderTest {
 
     @Language("java")

--- a/components/sbm-recipes-jee-to-boot/src/main/java/org/springframework/sbm/jee/jpa/actions/RenameUnitNameOfPersistenceContextAnnotationsToDefault.java
+++ b/components/sbm-recipes-jee-to-boot/src/main/java/org/springframework/sbm/jee/jpa/actions/RenameUnitNameOfPersistenceContextAnnotationsToDefault.java
@@ -49,7 +49,7 @@ public class RenameUnitNameOfPersistenceContextAnnotationsToDefault extends Abst
                     .map(m -> m.getAnnotation(PERSISTENCE_CONTEXT))
                     .findFirst()
                     .get()
-                    .setAttribute("unitName", "default", String.class);
+                    .removeAttribute("unitName");
                 });
     }
 }

--- a/components/sbm-recipes-jee-to-boot/src/main/resources/recipes/migrate-jpa-to-spring-boot.yaml
+++ b/components/sbm-recipes-jee-to-boot/src/main/resources/recipes/migrate-jpa-to-spring-boot.yaml
@@ -68,6 +68,15 @@
         This action will delete explicit 'hibernate' and related dependencies from a build file
         as they are transitively managed by 'spring-boot-starter-data-jpa' dependency.
 
+    - type: org.springframework.sbm.build.migration.actions.RemoveDependenciesMatchingRegex
+      condition:
+        type: org.springframework.sbm.common.migration.conditions.TrueCondition
+      dependenciesRegex:
+        - com\.oracle\.weblogic\:com\.oracle\.weblogic\.persistence:.*
+      description: Delete WebLogic related dependency
+      detailedDescription: |-
+        This action will delete com.oracle.weblogic.persistence dependency from a build file.
+
     - type: org.springframework.sbm.java.migration.actions.AddTypeAnnotationToTypeAnnotatedWith
       condition:
         type: org.springframework.sbm.jee.ejb.conditions.NoTransactionalAnnotationPresentOnTypeAnnotatedWith

--- a/components/sbm-recipes-jee-to-boot/src/main/resources/recipes/migrate-jpa-to-spring-boot.yaml
+++ b/components/sbm-recipes-jee-to-boot/src/main/resources/recipes/migrate-jpa-to-spring-boot.yaml
@@ -99,7 +99,7 @@
       pattern: '/**/persistence.xml'
 
     - type: org.springframework.sbm.jee.jpa.actions.RenameUnitNameOfPersistenceContextAnnotationsToDefault
-      description: Set 'unitName' attribute from @PersistenceContext annotations to 'default' when different
+      description: Remove unitName attribute from @PersistenceContext annotations to use the default persistence unit
       condition:
         type: org.springframework.sbm.java.migration.conditions.HasMemberAnnotation
         annotation: javax.persistence.PersistenceContext

--- a/components/sbm-recipes-jee-to-boot/src/test/java/org/springframework/sbm/jee/jpa/actions/RenameUnitNameOfPersistenceContextAnnotationsToDefaultTest.java
+++ b/components/sbm-recipes-jee-to-boot/src/test/java/org/springframework/sbm/jee/jpa/actions/RenameUnitNameOfPersistenceContextAnnotationsToDefaultTest.java
@@ -50,7 +50,7 @@ class RenameUnitNameOfPersistenceContextAnnotationsToDefaultTest {
                 import javax.persistence.PersistenceContext;
                 import javax.persistence.EntityManager;
                 public class Foo {
-                    @PersistenceContext(unitName = "default")
+                    @PersistenceContext
                     private EntityManager entityManager;
                 }
                 """;

--- a/components/sbm-recipes-jee-to-boot/src/test/java/org/springframework/sbm/jee/jpa/recipes/MigrateJpaToSpringBootRecipeTest.java
+++ b/components/sbm-recipes-jee-to-boot/src/test/java/org/springframework/sbm/jee/jpa/recipes/MigrateJpaToSpringBootRecipeTest.java
@@ -52,6 +52,7 @@ public class MigrateJpaToSpringBootRecipeTest {
                     AddDependencies.class,
                     AddDependencies.class,
                     RemoveDependenciesMatchingRegex.class,
+                    RemoveDependenciesMatchingRegex.class,
                     AddTypeAnnotationToTypeAnnotatedWith.class,
                     MigrateEclipseLinkToSpringBoot.class,
                     DeleteFileMatchingPattern.class,

--- a/docs/reference/user-documentation.adoc
+++ b/docs/reference/user-documentation.adoc
@@ -24,12 +24,11 @@ The application to be migrated must meet these requirements:
 * Must ba a Maven project
 * Must follow Maven dir layout
 * Should have Git (be in a repo)
-* No Maven reactor support (only one pom.xml!)
 * Recent build with `mvn clean package` and target dir still exists
 
 Your System must meet these requirements:
 
-* Java version 11+
+* Java version 17
 
 
 == Getting started


### PR DESCRIPTION
- Migrate JPA to Spring Boot - Remove unitName attribute from @PersistenceContext annotations to use the default persistence unit
- Migrate JPA to Spring Boot - Remove com.oracle.weblogic:com.oracle.weblogic.persistence:.* dependecy
- Fix GitHub build
- Disable ApacheSolrRepositoryBeanFinderTest because it is outdated and depends on artifacts that are no longer available
- Update documentations